### PR TITLE
Restore last chunk download for debugging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+### Next task for the next agent (post test)
+
+Assuming STOP now downloads the last chunk successfully on device, proceed to reintroduce the original save flow behind a runtime toggle and use it to bisect the regression.
+
+- **Implement runtime toggle**: Add a URL param `dl` read in `apps/videodelay/app.js` controlling how the recorded blob is assembled on stop.
+  - `dl=last` (default): return only the last non-empty chunk (current debug behavior).
+  - `dl=concat`: return a Blob of all collected chunks (previous behavior).
+- **Keep immediate save on STOP**: Continue triggering `saveBlobAs` directly on STOP for both modes so the download gesture is consistent.
+- **Add lightweight diagnostics**: Log to console and (briefly) to `overlay` the chosen mode, recorder type (element vs canvas), chunk count and total size, final blob type/size, and which save path was used (File System Access vs anchor fallback). Capture any thrown errors.
+- **Device test matrix**: On the target phone, verify `?dl=last` still downloads. Then try `?dl=concat` and note whether download fails or the file is corrupt/unplayable. Record exact symptoms and logs.
+- **Outcome**: Identify whether the failure is in chunk assembly, MIME/extension handling, or the save path. Commit the toggle/logs as temporary debugging aids with a clear message and leave default as `last`.

--- a/apps/videodelay/app.js
+++ b/apps/videodelay/app.js
@@ -245,9 +245,10 @@
     };
     elementRecorder.onstop = () => {
       if (elementRecorderStopResolve) {
-        const chunkType = (elementRecorderChunks.find(c => c && c.type) || {}).type || (elementRecorder && elementRecorder.mimeType) || 'video/webm';
+        const lastChunk = [...elementRecorderChunks].reverse().find(c => c && c.size > 0);
+        const chunkType = (lastChunk && lastChunk.type) || (elementRecorder && elementRecorder.mimeType) || 'video/webm';
         const normalized = normalizeMimeType(chunkType);
-        elementRecorderStopResolve(new Blob(elementRecorderChunks, { type: normalized }));
+        elementRecorderStopResolve(new Blob(lastChunk ? [lastChunk] : [], { type: normalized }));
         elementRecorderStopResolve = null;
       }
     };
@@ -304,9 +305,10 @@
     };
     canvasRecorder.onstop = () => {
       if (canvasRecorderStopResolve) {
-        const chunkType = (canvasRecorderChunks.find(c => c && c.type) || {}).type || (canvasRecorder && canvasRecorder.mimeType) || 'video/webm';
+        const lastChunk = [...canvasRecorderChunks].reverse().find(c => c && c.size > 0);
+        const chunkType = (lastChunk && lastChunk.type) || (canvasRecorder && canvasRecorder.mimeType) || 'video/webm';
         const normalized = normalizeMimeType(chunkType);
-        canvasRecorderStopResolve(new Blob(canvasRecorderChunks, { type: normalized }));
+        canvasRecorderStopResolve(new Blob(lastChunk ? [lastChunk] : [], { type: normalized }));
         canvasRecorderStopResolve = null;
       }
     };
@@ -381,11 +383,11 @@
       }
 
       if (blob && blob.size > 0) {
-        readyToSaveBlob = blob;
-        recBtn.textContent = 'SAVE';
-      } else {
-        recBtn.textContent = 'REC';
+        const ext = getExtensionFromMime(blob.type);
+        const filename = `delayed-recording-${Date.now()}.${ext}`;
+        try { await saveBlobAs(blob, filename); } catch (_) {}
       }
+      recBtn.textContent = 'REC';
       try { recBtn.disabled = false; } catch (_) {}
     }
   }


### PR DESCRIPTION
Temporarily restore `apps/videodelay` download functionality to save only the last chunk immediately on stop, to debug a download regression.

This change enables a simplified download flow to help bisect a recent regression where downloads were failing, by ensuring a download occurs and contains only the final recorded chunk.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6cbc9a2-1a55-47e2-b588-6d779a1dad06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6cbc9a2-1a55-47e2-b588-6d779a1dad06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

