### PR TITLE
Fix whatsapp video sharing compatibility

### DIFF
--- a/apps/videodelay/app.js
+++ b/apps/videodelay/app.js
@@ -37,6 +37,45 @@
   let canvasRecorderChunks = [];
   let canvasRecorderStopResolve = null;
 
+  // Optional silent audio to make containers more widely acceptable (e.g., WhatsApp)
+  let silenceAudioContext = null;
+  let silenceOscillator = null;
+  let silenceGain = null;
+  let silenceDestination = null;
+  let silenceAudioTrack = null;
+
+  function ensureSilenceAudioTrack() {
+    try {
+      if (silenceAudioTrack && silenceAudioTrack.readyState === 'live') return silenceAudioTrack;
+      const AudioContextCtor = (window.AudioContext || window.webkitAudioContext);
+      if (!AudioContextCtor) return null;
+      silenceAudioContext = silenceAudioContext || new AudioContextCtor();
+      silenceDestination = silenceAudioContext.createMediaStreamDestination();
+      silenceOscillator = silenceAudioContext.createOscillator();
+      silenceGain = silenceAudioContext.createGain();
+      // Keep frames flowing but inaudible
+      silenceGain.gain.value = 0.00001;
+      silenceOscillator.connect(silenceGain).connect(silenceDestination);
+      try { silenceOscillator.start(); } catch (_) { /* already started */ }
+      const tracks = silenceDestination.stream.getAudioTracks();
+      silenceAudioTrack = tracks && tracks[0] ? tracks[0] : null;
+      return silenceAudioTrack || null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function cleanupSilenceAudioTrack() {
+    try { if (silenceOscillator) silenceOscillator.stop(); } catch (_) {}
+    try { if (silenceAudioTrack) silenceAudioTrack.stop(); } catch (_) {}
+    try { if (silenceAudioContext && typeof silenceAudioContext.close === 'function') silenceAudioContext.close(); } catch (_) {}
+    silenceOscillator = null;
+    silenceGain = null;
+    silenceDestination = null;
+    silenceAudioTrack = null;
+    silenceAudioContext = null;
+  }
+
   function chooseBestMimeType() {
     // Prefer MP4/H.264 when available (better compatibility e.g., WhatsApp/iOS)
     const candidates = [
@@ -250,12 +289,18 @@
   let recordingStrategy = DelayCamLogic.chooseRecordingStrategy({});
 
   function startElementCaptureRecording() {
-    const stream = delayedVideo.captureStream ? delayedVideo.captureStream() : null;
-    if (!stream) return;
+    const srcStream = delayedVideo.captureStream ? delayedVideo.captureStream() : null;
+    if (!srcStream) return;
     elementRecorderChunks = [];
+    const recStream = new MediaStream();
+    try { srcStream.getVideoTracks().forEach(t => recStream.addTrack(t)); } catch (_) {}
+    const silentTrack = ensureSilenceAudioTrack();
+    if (silentTrack) {
+      try { recStream.addTrack(silentTrack); } catch (_) {}
+    }
     const mimeType = chooseBestMimeType();
-    const options = mimeType ? { mimeType, videoBitsPerSecond: 3_000_000 } : { videoBitsPerSecond: 3_000_000 };
-    elementRecorder = new MediaRecorder(stream, options);
+    const options = mimeType ? { mimeType, videoBitsPerSecond: 3_000_000, audioBitsPerSecond: 96_000 } : { videoBitsPerSecond: 3_000_000, audioBitsPerSecond: 96_000 };
+    elementRecorder = new MediaRecorder(recStream, options);
     elementRecorder.ondataavailable = e => {
       if (e.data && e.data.size > 0) {
         elementRecorderChunks.push(e.data);
@@ -282,6 +327,8 @@
       } else {
         resolve(new Blob([], { type: 'video/webm' }));
       }
+      // Clean up optional audio generators
+      cleanupSilenceAudioTrack();
     });
   }
 
@@ -319,9 +366,15 @@
     if (!canvasStream) return;
 
     canvasRecorderChunks = [];
+    const recStream = new MediaStream();
+    try { canvasStream.getVideoTracks().forEach(t => recStream.addTrack(t)); } catch (_) {}
+    const silentTrack = ensureSilenceAudioTrack();
+    if (silentTrack) {
+      try { recStream.addTrack(silentTrack); } catch (_) {}
+    }
     const mimeType = chooseBestMimeType();
-    const options = mimeType ? { mimeType, videoBitsPerSecond: 3_000_000 } : { videoBitsPerSecond: 3_000_000 };
-    canvasRecorder = new MediaRecorder(canvasStream, options);
+    const options = mimeType ? { mimeType, videoBitsPerSecond: 3_000_000, audioBitsPerSecond: 96_000 } : { videoBitsPerSecond: 3_000_000, audioBitsPerSecond: 96_000 };
+    canvasRecorder = new MediaRecorder(recStream, options);
     canvasRecorder.ondataavailable = e => {
       if (e.data && e.data.size > 0) {
         canvasRecorderChunks.push(e.data);
@@ -356,6 +409,8 @@
       } else {
         resolve(new Blob([], { type: 'video/webm' }));
       }
+      // Clean up optional audio generators
+      cleanupSilenceAudioTrack();
     });
   }
 

--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -73,7 +73,7 @@
   <button id="switchBtn">&#8635;</button>
   <button id="recBtn">REC</button>
   <div id="recordDot"></div>
-  <div id="versionLabel">1.0.1</div>
+  <div id="versionLabel">1.1.0</div>
 
   <script src="logic.js"></script>
   <script src="app.js"></script>

--- a/apps/videodelay/logic.js
+++ b/apps/videodelay/logic.js
@@ -39,9 +39,7 @@
     }
   }
 
-  // Naive concatenation of WebM chunks. This is known to be unsafe
-  // because WebM containers contain their own headers and timestamps.
-  // We keep it for fallback and to write tests that fail first.
+  // Naive concatenation of WebM chunks (kept for tests/fallback).
   function combineWebMChunks(chunks) {
     return new Blob(chunks, { type: 'video/webm' });
   }

--- a/apps/videodelay/service-worker.js
+++ b/apps/videodelay/service-worker.js
@@ -1,6 +1,6 @@
 // apps/videodelay/service-worker.js
 
-const CACHE_NAME = 'delay-camera-cache-v2';
+const CACHE_NAME = 'delay-camera-cache-v3';
 
 // 1) The root URL (“./”) ensures index.html is served at /apps/videodelay/ offline.
 // 2) Then we list each file by its exact relative path:

--- a/tests/delaycam.share.spec.js
+++ b/tests/delaycam.share.spec.js
@@ -1,0 +1,91 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+// Grant permissions per test (aligns with existing spec)
+test.beforeEach(async ({ context, baseURL }) => {
+  if (baseURL) {
+    await context.grantPermissions(['camera'], { origin: baseURL });
+  }
+});
+
+async function navigateToDelayCam(page) {
+  const firstPath = '/apps/videodelay/index.html';
+  const secondPath = '/apps/videodelay.html';
+  let res = await page.goto(firstPath);
+  if (!res || !res.ok()) {
+    await page.goto(secondPath);
+  }
+}
+
+async function goToDelayedMode(page) {
+  await navigateToDelayCam(page);
+  await page.locator('#liveVideo').click({ position: { x: 20, y: 700 } });
+  await page.waitForTimeout(300);
+  await page.locator('#liveVideo').click({ position: { x: 20, y: 700 } });
+  await page.waitForTimeout(250);
+}
+
+// When share isn't available, SAVE should download and have a sane extension
+test('SAVE triggers download with correct extension when share unsupported', async ({ page }) => {
+  await goToDelayedMode(page);
+
+  // Start and stop to get a blob ready to save
+  await page.click('#recBtn');
+  await page.waitForTimeout(700);
+  await page.click('#recBtn'); // shows SAVE
+  await expect(page.locator('#recBtn')).toHaveText('SAVE');
+
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('#recBtn'), // trigger save
+  ]);
+
+  const suggested = download.suggestedFilename();
+  expect(/delayed-recording-\d+\.(webm|mp4)$/.test(suggested)).toBeTruthy();
+
+  // Ensure UI resets
+  await expect(page.locator('#recBtn')).toHaveText('REC');
+});
+
+// When share is available, SAVE should call navigator.share with a File
+test('SAVE uses Web Share API when available and passes a File', async ({ page }) => {
+  await goToDelayedMode(page);
+
+  // Start and stop to get a blob ready to save
+  await page.click('#recBtn');
+  await page.waitForTimeout(700);
+  await page.click('#recBtn'); // shows SAVE
+  await expect(page.locator('#recBtn')).toHaveText('SAVE');
+
+  // Stub share APIs in the page to capture the shared file
+  await page.evaluate(() => {
+    window.__shareCalled = false;
+    window.__sharedFiles = [];
+    const nav = navigator;
+    // Simple canShare implementation: return true if files present
+    nav.canShare = (data) => !!(data && data.files && data.files.length);
+    nav.share = async (data) => {
+      window.__shareCalled = true;
+      window.__sharedFiles = (data && data.files) ? data.files : [];
+      return;
+    };
+  });
+
+  // Click SAVE; this should call navigator.share and NOT download
+  await page.click('#recBtn');
+
+  // Give the promise chain a moment to resolve
+  await page.waitForTimeout(250);
+
+  const { called, names } = await page.evaluate(() => ({
+    called: !!window.__shareCalled,
+    names: (window.__sharedFiles || []).map(f => f && f.name)
+  }));
+
+  expect(called).toBeTruthy();
+  expect(names.length).toBe(1);
+  expect(/delayed-recording-\d+\.(webm|mp4)$/.test(names[0])).toBeTruthy();
+
+  // Ensure UI resets
+  await expect(page.locator('#recBtn')).toHaveText('REC');
+});


### PR DESCRIPTION
Improve video file compatibility for sharing (e.g., WhatsApp) by preferring MP4/H.264, adding a silent audio track, and enabling native sharing.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d29f0d0-f36b-42c9-978e-00113ea3293e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1d29f0d0-f36b-42c9-978e-00113ea3293e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

