### PR TITLE
Add copy link button before delay

### DIFF
--- a/apps/videodelay/app.js
+++ b/apps/videodelay/app.js
@@ -7,6 +7,7 @@
   const miniLive = document.getElementById('miniLive');
   const overlay = document.getElementById('overlay');
   const switchBtn = document.getElementById('switchBtn');
+  const copyLinkBtn = document.getElementById('copyLinkBtn');
   const recBtn = document.getElementById('recBtn');
   const recordDot = document.getElementById('recordDot');
 
@@ -475,6 +476,7 @@
     tapCount++;
     if (tapCount === 1) {
       switchBtn.style.display = 'none';
+      if (copyLinkBtn) copyLinkBtn.style.display = 'none';
       startStopwatch();
       firstChunkPromise = startRecording();
     } else if (tapCount === 2) {
@@ -504,6 +506,35 @@
     currentFacingMode = currentFacingMode === 'user' ? 'environment' : 'user';
     await startCamera();
   });
+
+  // Copy app link button: visible before setting delay; copies current app URL
+  if (copyLinkBtn) {
+    try {
+      copyLinkBtn.style.display = 'inline-block';
+    } catch (_) {}
+    copyLinkBtn.addEventListener('click', async () => {
+      const url = location.href;
+      try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          await navigator.clipboard.writeText(url);
+        } else {
+          const ta = document.createElement('textarea');
+          ta.value = url;
+          ta.setAttribute('readonly', '');
+          ta.style.position = 'absolute';
+          ta.style.left = '-9999px';
+          document.body.appendChild(ta);
+          ta.select();
+          document.execCommand('copy');
+          document.body.removeChild(ta);
+        }
+        copyLinkBtn.textContent = 'copied! ✅';
+        setTimeout(() => { try { copyLinkBtn.textContent = 'copy app link 🔗'; } catch (_) {} }, 1500);
+      } catch (_) {
+        // Silent failure; no UX change
+      }
+    });
+  }
 
   miniLive.addEventListener('click', () => {
     location.reload();

--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -34,6 +34,12 @@
       font-size: 1.4em; border-radius: 50%; width: 56px; height: 56px;
       cursor: pointer; display: flex; align-items: center; justify-content: center;
     }
+    #copyLinkBtn {
+      position: absolute; top: 15px; right: 84px; z-index: 4;
+      background: rgba(255,255,255,0.1); color: white; border: 1px solid white;
+      font-size: 1em; border-radius: 12px; padding: 0.5em 0.8em;
+      cursor: pointer;
+    }
     #recBtn {
       position: absolute; bottom: 10px; left: 10px; z-index: 5;
       background: rgba(255,255,255,0.1); color: white;
@@ -71,6 +77,7 @@
 
   <div id="overlay">Tap to set delay</div>
   <button id="switchBtn">&#8635;</button>
+  <button id="copyLinkBtn">copy app link 🔗</button>
   <button id="recBtn">REC</button>
   <div id="recordDot"></div>
   <div id="versionLabel">1.1.0</div>

--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -42,9 +42,26 @@
     }
     #recBtn {
       position: absolute; bottom: 10px; left: 10px; z-index: 5;
-      background: rgba(255,255,255,0.1); color: white;
+      background: rgba(255, 0, 0, 0.25); color: white;
       border: 2px solid red; font-size: 1.2em;
       padding: 0.8em 1.2em; border-radius: 14px;
+      cursor: pointer; display: none;
+      transition: background 0.3s ease, transform 0.2s ease;
+    }
+    #recBtn.recording {
+      background: rgba(255, 0, 0, 0.35);
+      animation: pulse 1s infinite;
+    }
+    @keyframes pulse {
+      0% { transform: scale(1); }
+      50% { transform: scale(1.03); }
+      100% { transform: scale(1); }
+    }
+    #cancelBtn {
+      position: absolute; bottom: 10px; left: 120px; z-index: 5;
+      background: rgba(255,255,255,0.1); color: white;
+      border: 2px solid #888; font-size: 1.1em;
+      padding: 0.7em 1.1em; border-radius: 14px;
       cursor: pointer; display: none;
     }
     #recordDot {
@@ -79,8 +96,9 @@
   <button id="switchBtn">&#8635;</button>
   <button id="copyLinkBtn">copy app link 🔗</button>
   <button id="recBtn">REC</button>
+  <button id="cancelBtn">CANCEL</button>
   <div id="recordDot"></div>
-  <div id="versionLabel">1.1.0</div>
+  <div id="versionLabel">1.2.0</div>
 
   <script src="logic.js"></script>
   <script src="app.js"></script>

--- a/apps/videodelay/service-worker.js
+++ b/apps/videodelay/service-worker.js
@@ -1,6 +1,6 @@
 // apps/videodelay/service-worker.js
 
-const CACHE_NAME = 'delay-camera-cache-v3';
+const CACHE_NAME = 'delay-camera-cache-v4';
 
 // 1) The root URL (“./”) ensures index.html is served at /apps/videodelay/ offline.
 // 2) Then we list each file by its exact relative path:


### PR DESCRIPTION
Add a "copy app link 🔗" button to the videodelay app for easy sharing, visible only before the delay is set.

---
<a href="https://cursor.com/background-agent?bcId=bc-66cf8300-d96d-41f0-b425-a0a84eb7729c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-66cf8300-d96d-41f0-b425-a0a84eb7729c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

