### PR TITLE
Fix and improve video delay app link sharing

### DIFF
--- a/apps/videodelay/app.js
+++ b/apps/videodelay/app.js
@@ -542,7 +542,11 @@
       try {
         if (canNativeShareLink) {
           try {
-            await navigator.share({ url, title: 'Video Delay Camera' });
+            await navigator.share({
+              url,
+              title: 'Capture key moments without filling your phone',
+              text: 'Record key soccer moments or catch shooting stars with a delayed camera. Free and ad‑free forever.'
+            });
             return;
           } catch (_) {
             // fall through to clipboard

--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -93,7 +93,7 @@
   <video id="miniLive" muted autoplay playsinline></video>
 
   <div id="overlay">Tap to set delay</div>
-  <button id="switchBtn">&#8635;</button>
+  <button id="switchBtn" aria-label="Switch camera" title="Switch camera">📸</button>
   <button id="copyLinkBtn">copy app link 🔗</button>
   <button id="recBtn">REC</button>
   <button id="cancelBtn">CANCEL</button>

--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -35,9 +35,9 @@
       cursor: pointer; display: flex; align-items: center; justify-content: center;
     }
     #copyLinkBtn {
-      position: absolute; top: 15px; right: 84px; z-index: 4;
+      position: absolute; bottom: 15px; right: 15px; z-index: 4;
       background: rgba(255,255,255,0.1); color: white; border: 1px solid white;
-      font-size: 1em; border-radius: 12px; padding: 0.5em 0.8em;
+      font-size: 1em; border-radius: 12px; padding: 0.6em 0.9em;
       cursor: pointer;
     }
     #recBtn {
@@ -98,7 +98,7 @@
   <button id="recBtn">REC</button>
   <button id="cancelBtn">CANCEL</button>
   <div id="recordDot"></div>
-  <div id="versionLabel">1.2.0</div>
+  <div id="versionLabel">1.2.1</div>
 
   <script src="logic.js"></script>
   <script src="app.js"></script>

--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -93,7 +93,7 @@
   <video id="miniLive" muted autoplay playsinline></video>
 
   <div id="overlay">Tap to set delay</div>
-  <button id="switchBtn" aria-label="Switch camera" title="Switch camera">📸</button>
+  <button id="switchBtn" aria-label="Switch camera" title="Switch camera">📸↻</button>
   <button id="copyLinkBtn">copy app link 🔗</button>
   <button id="recBtn">REC</button>
   <button id="cancelBtn">CANCEL</button>

--- a/apps/videodelay/service-worker.js
+++ b/apps/videodelay/service-worker.js
@@ -1,6 +1,6 @@
 // apps/videodelay/service-worker.js
 
-const CACHE_NAME = 'delay-camera-cache-v4';
+const CACHE_NAME = 'delay-camera-cache-v5';
 
 // 1) The root URL (“./”) ensures index.html is served at /apps/videodelay/ offline.
 // 2) Then we list each file by its exact relative path:

--- a/apps/videodelay/service-worker.js
+++ b/apps/videodelay/service-worker.js
@@ -1,6 +1,6 @@
 // apps/videodelay/service-worker.js
 
-const CACHE_NAME = 'delay-camera-cache-v5';
+const CACHE_NAME = 'delay-camera-cache-v6';
 
 // 1) The root URL (“./”) ensures index.html is served at /apps/videodelay/ offline.
 // 2) Then we list each file by its exact relative path:


### PR DESCRIPTION
Improve the app link button's functionality and placement, and bump the app version to 1.2.1.

The app link button previously failed to copy the URL in PWA contexts due to scope issues, now resolved by using a hard-coded URL. It also now prefers native sharing when available and has been repositioned to avoid overlapping other UI elements. The service worker cache has been bumped to ensure all users receive these updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-a23720b0-1bee-49af-a189-b38bb102ffa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a23720b0-1bee-49af-a189-b38bb102ffa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

