### PR TITLE
Add camera zoom control buttons

### DIFF
--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -34,6 +34,28 @@
       font-size: 1.4em; border-radius: 50%; width: 56px; height: 56px;
       cursor: pointer; display: flex; align-items: center; justify-content: center;
     }
+    #zoomControls {
+      position: absolute;
+      top: 80px; /* below the switch button */
+      right: 15px;
+      z-index: 4;
+      display: flex;
+      gap: 8px;
+    }
+    .zoomBtn {
+      background: rgba(255,255,255,0.1);
+      color: white;
+      border: 1px solid white;
+      font-size: 0.95em;
+      border-radius: 12px;
+      padding: 0.35em 0.6em;
+      cursor: pointer;
+      user-select: none;
+    }
+    .zoomBtn.selected {
+      background: white;
+      color: black;
+    }
     #copyLinkBtn {
       position: absolute; bottom: 15px; right: 15px; z-index: 4;
       background: rgba(255,255,255,0.1); color: white; border: 1px solid white;
@@ -94,6 +116,7 @@
 
   <div id="overlay">Tap to set delay</div>
   <button id="switchBtn" aria-label="Switch camera" title="Switch camera">📸↻</button>
+  <div id="zoomControls" role="group" aria-label="Zoom controls"></div>
   <button id="copyLinkBtn">copy app link 🔗</button>
   <button id="recBtn">REC</button>
   <button id="cancelBtn">CANCEL</button>

--- a/tests/delaycam.zoom.spec.js
+++ b/tests/delaycam.zoom.spec.js
@@ -1,0 +1,115 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+// Ensure camera permission and stub PTZ to force CSS zoom path
+test.beforeEach(async ({ context, baseURL, page }) => {
+  if (baseURL) {
+    await context.grantPermissions(['camera'], { origin: baseURL });
+  }
+  // Disable PTZ so CSS transform path is used in tests
+  await page.addInitScript(() => {
+    try {
+      Object.defineProperty(MediaStreamTrack.prototype, 'getCapabilities', {
+        configurable: true,
+        writable: true,
+        value: function () { return {}; }
+      });
+    } catch (_) {}
+  });
+});
+
+async function navigateToDelayCam(page) {
+  const firstPath = '/apps/videodelay/index.html';
+  const secondPath = '/apps/videodelay.html';
+  let res = await page.goto(firstPath);
+  if (!res || !res.ok()) {
+    await page.goto(secondPath);
+  }
+}
+
+function zoomButtonsLocator(page) {
+  return page.locator('#zoomControls .zoomBtn');
+}
+
+function zoomButtonByLabel(page, label) {
+  return page.locator('#zoomControls .zoomBtn', { hasText: label });
+}
+
+// UI presence and default selection
+test('zoom controls visible with 5 buttons and default 1x selected', async ({ page }) => {
+  await navigateToDelayCam(page);
+  await expect(page.locator('#zoomControls')).toBeVisible();
+  const btns = zoomButtonsLocator(page);
+  await expect(btns).toHaveCount(5);
+  const labels = await btns.allTextContents();
+  expect(labels).toEqual(['1x', '1.2x', '1.4x', '1.7x', '2x']);
+  await expect(page.locator('#zoomControls .zoomBtn.selected')).toHaveText('1x');
+});
+
+// Clicking a zoom button selects it and applies CSS transform (PTZ off)
+test('clicking 2x selects it and applies display zoom', async ({ page }) => {
+  await navigateToDelayCam(page);
+  await zoomButtonByLabel(page, '2x').click();
+  await expect(page.locator('#zoomControls .zoomBtn.selected')).toHaveText('2x');
+  const liveTransform = await page.evaluate(() => document.getElementById('liveVideo').style.transform || '');
+  expect(liveTransform).toContain('scale(2)');
+});
+
+// Controls persist in delayed mode and apply to delayedVideo as well
+test('zoom controls persist in delayed mode and affect delayedVideo', async ({ page }) => {
+  await navigateToDelayCam(page);
+  await zoomButtonByLabel(page, '1.7x').click();
+  // Enter delayed mode
+  await page.locator('#liveVideo').click({ position: { x: 20, y: 700 } });
+  await page.waitForTimeout(200);
+  await page.locator('#liveVideo').click({ position: { x: 20, y: 700 } });
+  await page.waitForTimeout(250);
+  await expect(page.locator('#delayedVideo')).toBeVisible();
+  await expect(page.locator('#zoomControls')).toBeVisible();
+  const delayedTransform = await page.evaluate(() => document.getElementById('delayedVideo').style.transform || '');
+  expect(delayedTransform).toContain('scale(1.7)');
+});
+
+// Basic record flow after zoom to ensure pipeline still works
+// (We do not assert visual zoom inside recorded file here.)
+const fs = require('fs');
+
+test('recording still works after applying zoom', async ({ page }) => {
+  await navigateToDelayCam(page);
+  await zoomButtonByLabel(page, '1.4x').click();
+  await page.locator('#liveVideo').click({ position: { x: 20, y: 700 } });
+  await page.waitForTimeout(250);
+  await page.locator('#liveVideo').click({ position: { x: 20, y: 700 } });
+  await page.waitForTimeout(250);
+
+  await page.click('#recBtn');
+  await page.waitForTimeout(700);
+  await page.click('#recBtn'); // stop -> SAVE
+  await expect(page.locator('#recBtn')).toHaveText(/SAVE|SHARE/);
+
+  // If SAVE, expect a download; if SHARE, stub to force download fallback
+  const hasShare = await page.evaluate(() => {
+    try {
+      const f = new File([new Blob(['x'], { type: 'video/webm' })], 'x.webm', { type: 'video/webm' });
+      return !!(navigator && navigator.canShare && navigator.share && navigator.canShare({ files: [f] }));
+    } catch (_) { return false; }
+  });
+
+  if (hasShare) {
+    // Replace share with save to get a download artifact we can assert
+    await page.evaluate(() => {
+      const nav = navigator;
+      nav.canShare = undefined;
+      nav.share = undefined;
+    });
+    await page.locator('#recBtn').click(); // now SAVE path
+  }
+
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.locator('#recBtn').click(),
+  ]);
+  const path = await download.path();
+  const size = (await fs.promises.stat(path)).size;
+  expect(size).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Add 5-step camera zoom controls to the videodelay app, using PTZ or CSS scaling.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5ea8f0b-d1a3-41ea-99ba-0d1f8e4b023d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5ea8f0b-d1a3-41ea-99ba-0d1f8e4b023d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

