### PR TITLE
Update app/videodelay patch version

### DIFF
--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -121,7 +121,7 @@
   <button id="recBtn">REC</button>
   <button id="cancelBtn">CANCEL</button>
   <div id="recordDot"></div>
-  <div id="versionLabel">1.2.1</div>
+  <div id="versionLabel">1.2.2</div>
 
   <script src="logic.js"></script>
   <script src="app.js"></script>

--- a/apps/videodelay/service-worker.js
+++ b/apps/videodelay/service-worker.js
@@ -1,6 +1,6 @@
 // apps/videodelay/service-worker.js
 
-const CACHE_NAME = 'delay-camera-cache-v6';
+const CACHE_NAME = 'delay-camera-cache-v7';
 
 // 1) The root URL (“./”) ensures index.html is served at /apps/videodelay/ offline.
 // 2) Then we list each file by its exact relative path:


### PR DESCRIPTION
Update the version label in `apps/videodelay/index.html` to 1.2.2.

---
<a href="https://cursor.com/background-agent?bcId=bc-47ec2c2a-dccc-4cee-a470-044268d3f9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-47ec2c2a-dccc-4cee-a470-044268d3f9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

