### PR TITLE
Update video delay share message and versions

### DIFF
--- a/apps/videodelay/app.js
+++ b/apps/videodelay/app.js
@@ -667,11 +667,11 @@
       try {
         if (canNativeShareLink) {
           try {
-            await navigator.share({
-              url,
-              title: 'Capture key moments without filling your phone',
-              text: 'Record key soccer moments or catch shooting stars with a delayed camera. Free and ad‑free forever.'
-            });
+              await navigator.share({
+                url,
+                title: 'Capture key moments without filling your phone',
+                text: 'Record key soccer moments or catch shooting stars with a delayed camera.'
+              });
             return;
           } catch (_) {
             // fall through to clipboard

--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -127,7 +127,7 @@
   <button id="recBtn">REC</button>
   <button id="cancelBtn">CANCEL</button>
   <div id="recordDot"></div>
-  <div id="versionLabel">1.2.3</div>
+    <div id="versionLabel">1.2.4</div>
 
   <script src="logic.js"></script>
   <script src="app.js"></script>

--- a/apps/videodelay/service-worker.js
+++ b/apps/videodelay/service-worker.js
@@ -1,6 +1,6 @@
 // apps/videodelay/service-worker.js
 
-const CACHE_NAME = 'delay-camera-cache-v8';
+const CACHE_NAME = 'delay-camera-cache-v9';
 
 // 1) The root URL (“./”) ensures index.html is served at /apps/videodelay/ offline.
 // 2) Then we list each file by its exact relative path:


### PR DESCRIPTION
Update the video delay app's share message, version label, and service worker cache to remove the "free and ad-free forever" claim, reflect a patch release, and ensure PWA clients receive the updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-aead8805-ee52-421a-9288-42436835f78a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aead8805-ee52-421a-9288-42436835f78a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

