### PR TITLE
Add all comparison and boolean operators

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -120,6 +120,41 @@ test('parses less-than comparisons using real parts', () => {
   assert.equal(node.right.kind, 'Const');
 });
 
+test('parses the remaining comparison operators', () => {
+  const gt = parseFormulaInput('x > y');
+  assert.equal(gt.ok, true);
+  assert.equal(gt.value.kind, 'GreaterThan');
+
+  const ge = parseFormulaInput('x >= y');
+  assert.equal(ge.ok, true);
+  assert.equal(ge.value.kind, 'GreaterThanOrEqual');
+
+  const le = parseFormulaInput('x <= y');
+  assert.equal(le.ok, true);
+  assert.equal(le.value.kind, 'LessThanOrEqual');
+
+  const eq = parseFormulaInput('x == y');
+  assert.equal(eq.ok, true);
+  assert.equal(eq.value.kind, 'Equal');
+});
+
+test('parses logical and/or with correct precedence', () => {
+  const result = parseFormulaInput('x < y && y < z || z == x');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'LogicalOr');
+  assert.equal(result.value.left.kind, 'LogicalAnd');
+  assert.equal(result.value.left.left.kind, 'LessThan');
+  assert.equal(result.value.left.right.kind, 'LessThan');
+  assert.equal(result.value.right.kind, 'Equal');
+});
+
+test('parses abs() calls as unary functions', () => {
+  const result = parseFormulaInput('abs(z)');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Abs');
+  assert.equal(result.value.value.kind, 'Var');
+});
+
 test('parses if expressions with embedded comparisons', () => {
   const result = parseFormulaInput('if(x < y, x + 1, y + 2)');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -380,7 +380,7 @@ function deriveFingerState(usage) {
 function syncFingerUI() {
   const activeLabels = activeFingerState.slots;
   if (fingerIndicatorStack) {
-    fingerIndicatorStack.style.display = activeLabels.length ? '' : 'none';
+    fingerIndicatorStack.style.display = activeLabels.length ? 'flex' : 'none';
   }
   if (fingerOverlay) {
     fingerOverlay.style.display = activeLabels.length ? 'block' : 'none';

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -328,6 +328,7 @@ function detectFingerUsage(ast) {
       case 'Sin':
       case 'Cos':
       case 'Ln':
+      case 'Abs':
         stack.push(node.value);
         break;
       case 'Sub':
@@ -336,6 +337,12 @@ function detectFingerUsage(ast) {
       case 'Add':
       case 'Div':
       case 'LessThan':
+      case 'GreaterThan':
+      case 'LessThanOrEqual':
+      case 'GreaterThanOrEqual':
+      case 'Equal':
+      case 'LogicalAnd':
+      case 'LogicalOr':
         stack.push(node.left, node.right);
         break;
       case 'Compose':


### PR DESCRIPTION
Adds support for all comparison operators, boolean operators, and the `abs()` function to the Reflex4You formula language to meet roadmap requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b828da2-3f84-4bf8-92c7-8fee9671bf5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b828da2-3f84-4bf8-92c7-8fee9671bf5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

