### PR TITLE
Add setup instructions for reflex formulas

### DIFF
--- a/apps/reflex4you/blogtest.html
+++ b/apps/reflex4you/blogtest.html
@@ -46,6 +46,14 @@
         background: rgba(255, 255, 255, 0.08);
         font-size: 0.95em;
       }
+      pre {
+        background: rgba(255, 255, 255, 0.05);
+        padding: 0.9rem;
+        border-radius: 10px;
+        overflow-x: auto;
+        font-size: 0.9em;
+        margin-top: 0.75rem;
+      }
       .instructions {
         font-size: 0.95em;
         color: #a3a3c1;
@@ -66,10 +74,16 @@
 
       <div class="instructions">
         <p>
-          Host the helper once and reference it via an absolute URL. For GitHub Pages the script will
-          live at
-          <code>https://mikaelmayer.github.io/apps/reflex4you/reflex-embed.js</code>. After tagging
-          <code>0.1.0</code> you can also load the immutable jsDelivr copy at
+          Add a container for each live canvas, then load the Reflex helper script once per page. The
+          snippet below is enough to light up another HTML document:
+        </p>
+        <pre><code>&lt;div class="reflex-block" reflex-formula="(z - 1) * (z + 1)"&gt;&lt;/div&gt;
+&lt;script type="module" src="https://cdn.jsdelivr.net/gh/MikaelMayer/MikaelMayer.github.io@0.1.0/apps/reflex4you/reflex-embed.js"&gt;&lt;/script&gt;</code></pre>
+        <p>Drop more <code>div</code>s with different <code>reflex-formula</code> values as needed.</p>
+        <p>
+          Host the helper once and reference it via an absolute URL. For GitHub Pages the script lives
+          at <code>https://mikaelmayer.github.io/apps/reflex4you/reflex-embed.js</code>, and the
+          immutable jsDelivr copy is
           <code
             >https://cdn.jsdelivr.net/gh/MikaelMayer/MikaelMayer.github.io@0.1.0/apps/reflex4you/reflex-embed.js</code
           >.

--- a/apps/reflex4you/blogtest.html
+++ b/apps/reflex4you/blogtest.html
@@ -54,6 +54,39 @@
         font-size: 0.9em;
         margin-top: 0.75rem;
       }
+      .formula-editor {
+        width: 100%;
+        min-height: 120px;
+        margin-top: 0.75rem;
+        border-radius: 10px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(0, 0, 0, 0.35);
+        color: #f8f8ff;
+        font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+        font-size: 0.95em;
+        padding: 0.75rem;
+        resize: vertical;
+      }
+      .code-copy {
+        cursor: pointer;
+        border: 1px solid rgba(58, 58, 183, 0.4);
+        transition: border-color 160ms ease, background 160ms ease;
+      }
+      .code-copy:hover {
+        border-color: rgba(90, 90, 255, 0.8);
+        background: rgba(255, 255, 255, 0.08);
+      }
+      .copy-status {
+        font-size: 0.85em;
+        color: #7f7fb3;
+        margin-top: 0.35rem;
+      }
+      .copy-status--success {
+        color: #71d08c;
+      }
+      .copy-status--error {
+        color: #ff9b71;
+      }
       .instructions {
         font-size: 0.95em;
         color: #a3a3c1;
@@ -84,6 +117,23 @@
           drop in as many Reflex blocks as you like:
         </p>
         <pre><code>&lt;script type="module" src="https://cdn.jsdelivr.net/gh/MikaelMayer/MikaelMayer.github.io@0.1.0/apps/reflex4you/reflex-embed.js"&gt;&lt;/script&gt;</code></pre>
+        <p>
+          Now if you want to integrate the Reflex with a specific formula, edit it here and watch the
+          embed code update instantly:
+        </p>
+        <textarea
+          class="formula-editor"
+          id="liveFormulaInput"
+        >(z - (-0.61-2.47i)) * (z - (-0.4-0.92i)) / (z - (-0.34+1.42i)) / 2 $$ 100</textarea>
+        <p>You just copy paste the following code into your web page:</p>
+        <pre class="code-copy" id="liveEmbedCode"><code id="liveEmbedCodeText"></code></pre>
+        <div class="copy-status" id="liveEmbedCopyStatus">Click to copy</div>
+        <p>You would then obtain the following display in your blog post:</p>
+        <div
+          class="reflex-block reflex-block--tall"
+          id="liveFormulaPreview"
+          reflex-formula="(z - (-0.61-2.47i)) * (z - (-0.4-0.92i)) / (z - (-0.34+1.42i)) / 2 $$ 100"
+        ></div>
         <p>
           That's it. Every <code>div</code> with a <code>reflex-formula</code> attribute becomes a
           live canvas driven by the reader's browser.
@@ -119,5 +169,68 @@
       type="module"
       src="https://cdn.jsdelivr.net/gh/MikaelMayer/MikaelMayer.github.io@0.1.0/apps/reflex4you/reflex-embed.js"
     ></script>
+    <script>
+      (function () {
+        const formulaInput = document.getElementById('liveFormulaInput');
+        const codeBlock = document.getElementById('liveEmbedCode');
+        const codeText = document.getElementById('liveEmbedCodeText');
+        const copyStatus = document.getElementById('liveEmbedCopyStatus');
+        const previewBlock = document.getElementById('liveFormulaPreview');
+        if (!formulaInput || !codeBlock || !codeText || !previewBlock || !copyStatus) {
+          return;
+        }
+
+        const defaultFormula = formulaInput.value.trim();
+        const buildEmbedCode = (formula) =>
+          `<div class="reflex-block reflex-block--tall" reflex-formula="${formula}"></div>`;
+
+        let latestCode = buildEmbedCode(defaultFormula);
+        let resetTimer = null;
+
+        function updateEmbedFromInput() {
+          const raw = formulaInput.value;
+          const normalized = raw.trim() || defaultFormula;
+          previewBlock.setAttribute('reflex-formula', normalized);
+          latestCode = buildEmbedCode(normalized);
+          codeText.textContent = latestCode;
+        }
+
+        function setCopyStatus(message, variant) {
+          copyStatus.textContent = message;
+          copyStatus.classList.remove('copy-status--success', 'copy-status--error');
+          if (variant) {
+            copyStatus.classList.add(variant);
+          }
+          if (resetTimer) {
+            clearTimeout(resetTimer);
+          }
+          resetTimer = setTimeout(() => {
+            copyStatus.textContent = 'Click to copy';
+            copyStatus.classList.remove('copy-status--success', 'copy-status--error');
+          }, 2000);
+        }
+
+        formulaInput.addEventListener('input', updateEmbedFromInput);
+
+        codeBlock.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(latestCode);
+            setCopyStatus('Copied!', 'copy-status--success');
+          } catch (err) {
+            setCopyStatus('Press ⌘/Ctrl+C to copy', 'copy-status--error');
+          }
+        });
+
+        updateEmbedFromInput();
+
+        const bootstrapIfReady = () => {
+          if (window.ReflexEmbed?.bootstrap) {
+            window.ReflexEmbed.bootstrap();
+          }
+        };
+        window.addEventListener('reflex-embed-ready', bootstrapIfReady, { once: true });
+        bootstrapIfReady();
+      })();
+    </script>
   </body>
 </html>

--- a/apps/reflex4you/blogtest.html
+++ b/apps/reflex4you/blogtest.html
@@ -65,45 +65,54 @@
   </head>
   <body>
     <article>
-      <h1>Embedding Reflex in Blog Posts</h1>
+      <h1>Reflex4You, Now Embeddable Anywhere</h1>
       <p>
-        Drop a <code>div</code> with a fixed height, add a
-        <code>reflex-formula</code> attribute, and include the loader scripts at the end of the
-        page. Each block becomes a live Reflex canvas.
+        I'm thrilled to say that Reflex4You canvases now drop directly into any blog or site. Each
+        frame renders on the reader's device, in real time, using the GPU—no screenshots, no waiting,
+        just live complex analysis wherever you publish.
+      </p>
+      <p>
+        If you want to play with formulas before you embed them, head to
+        <a href="https://mikaelmayer.github.io/apps/reflex4you/" target="_blank">reflex4you/</a>,
+        tweak an expression, and copy the one you like. The embeds below were generated exactly that
+        way.
       </p>
 
       <div class="instructions">
         <p>
-          Add a container for each live canvas, then load the Reflex helper script once per page. The
-          snippet below is enough to light up another HTML document:
+          Include the helper script once per page (ideally near the end of <code>body</code>), then
+          drop in as many Reflex blocks as you like:
         </p>
-        <pre><code>&lt;div class="reflex-block" reflex-formula="(z - 1) * (z + 1)"&gt;&lt;/div&gt;
-&lt;script type="module" src="https://cdn.jsdelivr.net/gh/MikaelMayer/MikaelMayer.github.io@0.1.0/apps/reflex4you/reflex-embed.js"&gt;&lt;/script&gt;</code></pre>
-        <p>Drop more <code>div</code>s with different <code>reflex-formula</code> values as needed.</p>
+        <pre><code>&lt;script type="module" src="https://cdn.jsdelivr.net/gh/MikaelMayer/MikaelMayer.github.io@0.1.0/apps/reflex4you/reflex-embed.js"&gt;&lt;/script&gt;</code></pre>
         <p>
-          Host the helper once and reference it via an absolute URL. For GitHub Pages the script lives
-          at <code>https://mikaelmayer.github.io/apps/reflex4you/reflex-embed.js</code>, and the
-          immutable jsDelivr copy is
-          <code
-            >https://cdn.jsdelivr.net/gh/MikaelMayer/MikaelMayer.github.io@0.1.0/apps/reflex4you/reflex-embed.js</code
-          >.
+          That's it. Every <code>div</code> with a <code>reflex-formula</code> attribute becomes a
+          live canvas driven by the reader's browser.
         </p>
       </div>
 
       <h2>Classic polynomial</h2>
-      <p>The zero set of <code>(z - 1) * (z + 1)</code> renders cleanly with two mirrored pockets.</p>
+      <p>
+        A simple <code>(z - 1) * (z + 1)</code> sketch shows how cleanly symmetric roots pop when the
+        GPU does the shading work on demand.
+      </p>
       <div class="reflex-block" reflex-formula="(z - 1) * (z + 1)"></div>
+      <pre><code>&lt;div class="reflex-block" reflex-formula="(z - 1) * (z + 1)"&gt;&lt;/div&gt;</code></pre>
 
       <h2>Rational function</h2>
       <p>
-        You can juxtapose multiple blocks with different heights. This one shows
-        <code>(z^2 + 1) / (z - i)</code>.
+        Taller canvases help when poles and zeros fight for attention. Here
+        <code>(z^2 + 1) / (z - i)</code> stretches vertically so the residue glow is easier to read.
       </p>
       <div class="reflex-block reflex-block--tall" reflex-formula="(z ^ 2 + 1) / (z - i)"></div>
+      <pre><code>&lt;div class="reflex-block reflex-block--tall" reflex-formula="(z ^ 2 + 1) / (z - i)"&gt;&lt;/div&gt;</code></pre>
 
       <h2>Quick iterations</h2>
-      <p>Throw any ad-hoc expression, such as <code>1 + z</code>, into its own block.</p>
+      <p>
+        Spontaneous ideas like <code>1 + z</code> deserve their own block too. Paste the formula,
+        watch it render instantly, and keep experimenting.
+      </p>
       <div class="reflex-block" reflex-formula="1 + z"></div>
+      <pre><code>&lt;div class="reflex-block" reflex-formula="1 + z"&gt;&lt;/div&gt;</code></pre>
     </article>
 
     <script


### PR DESCRIPTION
Transform `blogtest.html` into an announcement blog post for embeddable Reflex4You canvases, explaining client-side GPU rendering and providing clear embedding instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbecfea5-b489-4673-b477-7d006a5b5e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cbecfea5-b489-4673-b477-7d006a5b5e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

