### PR TITLE
Investigate if branch evaluation bug

### DIFF
--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -639,10 +639,11 @@ vec2 ${name}(vec2 z) {
     return `
 vec2 ${name}(vec2 z) {
     vec2 cond = ${condName}(z);
-    vec2 thenValue = ${thenName}(z);
-    vec2 elseValue = ${elseName}(z);
-    float selector = (cond.x != 0.0 || cond.y != 0.0) ? 1.0 : 0.0;
-    return mix(elseValue, thenValue, selector);
+    bool selector = (cond.x != 0.0 || cond.y != 0.0);
+    if (selector) {
+        return ${thenName}(z);
+    }
+    return ${elseName}(z);
 }`.trim();
   }
 

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -169,11 +169,12 @@ test('Logical operators implement non-zero truthiness', () => {
   assert.match(orFragment, /\|\|/);
 });
 
-test('If nodes mix branches based on non-zero condition', () => {
+test('If nodes branch based on non-zero condition', () => {
   const ast = If(Const(1, 0), Const(2, 0), Const(3, 0));
   const fragment = buildFragmentSourceFromAST(ast);
   assert.match(fragment, /vec2 cond =/);
-  assert.match(fragment, /mix\(elseValue, thenValue, selector\)/);
+  assert.match(fragment, /bool selector =/);
+  assert.match(fragment, /if \(selector\)/);
 });
 
 test('Abs nodes emit magnitude as real output', () => {


### PR DESCRIPTION
Refactor `If` node GLSL generation to use an `if` statement for lazy branch evaluation.

This change prevents inactive branches from being evaluated, which previously could cause visual artifacts due to unintended GPU state modifications from expensive or unstable computations in the unused branch.

---
<a href="https://cursor.com/background-agent?bcId=bc-5269137b-0a2e-4477-9dbc-fba26141ef69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5269137b-0a2e-4477-9dbc-fba26141ef69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

