### PR TITLE
Investigate formula color glitch in reflex4you

### DIFF
--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -727,6 +727,8 @@ uniform vec2 u_dynamicOffsets[3];
 out vec4 outColor;
 
 const float SQ3 = 1.7320508075688772;
+const float COLOR_MIN_MAG = 1.0e-6;
+const float COLOR_MIN_DEN = 1.0e-12;
 
 vec2 c_mul(vec2 a, vec2 b) {
   return vec2(
@@ -807,7 +809,7 @@ vec3 reflexColor(vec2 w) {
   float im = w.y;
   float m  = length(w);
 
-  if (m == 0.0) {
+  if (m <= COLOR_MIN_MAG) {
     return vec3(0.0);
   }
 
@@ -822,7 +824,7 @@ vec3 reflexColor(vec2 w) {
   float rpm  = re + m;
   float rpm2 = rpm * rpm;
   float i2   = im * im;
-  float den  = rpm2 + i2;
+  float den  = max(rpm2 + i2, COLOR_MIN_DEN);
 
   if (im == 0.0 && re <= 0.0) {
     g = 190.0;


### PR DESCRIPTION
Fixes color rendering glitch for near-zero complex numbers by preventing shader underflow.

Previously, extremely small complex numbers could cause the `reflexColor` shader's denominator to underflow to zero, leading to division by zero and an incorrect cyan color instead of black. This change introduces minimum thresholds for magnitude and denominator to ensure stable color calculations.

---
<a href="https://cursor.com/background-agent?bcId=bc-7424b8bb-344d-48b6-b510-566f3862c1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7424b8bb-344d-48b6-b510-566f3862c1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

