### PR TITLE
Debug d1 display in reflex4you index html

### DIFF
--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -348,6 +348,10 @@ function detectFingerUsage(ast) {
       case 'Compose':
         stack.push(node.f, node.g);
         break;
+      case 'SetBinding':
+      case 'LetBinding':
+        stack.push(node.value, node.body);
+        break;
       case 'If':
         stack.push(node.condition, node.thenBranch, node.elseBranch);
         break;

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -1,6 +1,7 @@
 const { test, expect } = require('@playwright/test');
 
-const SIMPLE_FORMULA = 'Add(Const(1.0, 0.0), Const(0.0, 1.0))';
+const SIMPLE_FORMULA = '(z - 1) * (z + 1)';
+const SEEDED_FORMULA = 'z + 2';
 const DYNAMIC_SET_FORMULA = 'set c = sin(z $ D1) in (1 - c + c * z) / (c + (1 - c) * z)';
 const FIXED_SET_FORMULA = 'set c = sin(z + F1) in (z - c) * (z + c)';
 
@@ -11,21 +12,21 @@ test('reflex4you updates formula query param after successful apply', async ({ p
   await expect(textarea).toBeVisible();
 
   await textarea.fill(SIMPLE_FORMULA);
-  await page.getByRole('button', { name: 'Apply' }).click();
-
-  const url = new URL(page.url());
-  const formulaInQuery = url.searchParams.get('formula');
-  expect(formulaInQuery).toBe(SIMPLE_FORMULA);
-
   await expect(page.locator('#error')).toBeHidden();
+  await expect.poll(async () => {
+    const href = await page.evaluate(() => window.location.href);
+    const url = new URL(href);
+    return url.searchParams.get('formula');
+  }).toBe(SIMPLE_FORMULA);
+
+  await expect(textarea).toHaveValue(SIMPLE_FORMULA);
 });
 
 test('reflex4you loads formulas from query string on startup', async ({ page }) => {
-  const seededFormula = 'Const(2.0, -1.5)';
-  await page.goto(`/index.html?formula=${encodeURIComponent(seededFormula)}`);
+  await page.goto(`/index.html?formula=${encodeURIComponent(SEEDED_FORMULA)}`);
 
   const textarea = page.locator('#formula');
-  await expect(textarea).toHaveValue(seededFormula);
+  await expect(textarea).toHaveValue(SEEDED_FORMULA);
 
   await expect(page.locator('#error')).toBeHidden();
 });

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -1,6 +1,8 @@
 const { test, expect } = require('@playwright/test');
 
 const SIMPLE_FORMULA = 'Add(Const(1.0, 0.0), Const(0.0, 1.0))';
+const DYNAMIC_SET_FORMULA = 'set c = sin(z $ D1) in (1 - c + c * z) / (c + (1 - c) * z)';
+const FIXED_SET_FORMULA = 'set c = sin(z + F1) in (z - c) * (z + c)';
 
 test('reflex4you updates formula query param after successful apply', async ({ page }) => {
   await page.goto('/index.html');
@@ -26,4 +28,26 @@ test('reflex4you loads formulas from query string on startup', async ({ page }) 
   await expect(textarea).toHaveValue(seededFormula);
 
   await expect(page.locator('#error')).toBeHidden();
+});
+
+test('shows D1 indicator when dynamic finger only appears inside set binding', async ({ page }) => {
+  await page.goto(`/index.html?formula=${encodeURIComponent(DYNAMIC_SET_FORMULA)}`);
+
+  const d1Indicator = page.locator('[data-finger="D1"]');
+  await expect(d1Indicator).toBeVisible();
+  await expect(d1Indicator).toHaveText(/D1 =/);
+
+  const fIndicators = page.locator('[data-finger^="F"]');
+  await expect(fIndicators).toHaveCount(0);
+});
+
+test('shows F1 indicator when fixed finger only appears inside set binding', async ({ page }) => {
+  await page.goto(`/index.html?formula=${encodeURIComponent(FIXED_SET_FORMULA)}`);
+
+  const f1Indicator = page.locator('[data-finger="F1"]');
+  await expect(f1Indicator).toBeVisible();
+  await expect(f1Indicator).toHaveText(/F1 =/);
+
+  const dIndicators = page.locator('[data-finger^="D"]');
+  await expect(dIndicators).toHaveCount(0);
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,7 +2,8 @@
 const { defineConfig, devices } = require('@playwright/test');
 
 module.exports = defineConfig({
-  testDir: './tests',
+  testDir: '.',
+  testMatch: /^(tests|apps\/reflex4you\/tests)\/.*\.spec\.js$/,
   timeout: 60000,
   retries: 0,
   use: {


### PR DESCRIPTION
Process `SetBinding` and `LetBinding` nodes in `detectFingerUsage` to correctly display finger usage for bound variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-326d050d-1cfe-416b-a7d3-1fce22f88700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-326d050d-1cfe-416b-a7d3-1fce22f88700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

