### PR TITLE
Fix mandelbrot formula parsing error

### DIFF
--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -226,6 +226,7 @@ const primitiveParser = Choice([
 
 let expressionParser;
 const expressionRef = lazy(() => expressionParser, { ctor: 'ExpressionRef' });
+const setBindingRef = lazy(() => setBindingParser, { ctor: 'SetBindingRef' });
 
 const groupedParser = Sequence([
   wsLiteral('(', { ctor: 'GroupOpen' }),
@@ -436,6 +437,7 @@ const primaryParser = Choice([
   explicitComposeParser,
   elementaryFunctionParser,
   ifParser,
+  setBindingRef,
   groupedParser,
   literalParser,
   primitiveParser,


### PR DESCRIPTION
Allow `set` bindings to be parsed in any expression position by including them in the `primaryParser`.

The original parser only recognized `set` bindings if they were at the very beginning of an expression. When a `set` binding appeared within a larger expression (e.g., after a `$`), the parser would fail with "Unexpected trailing characters." This change integrates `set` expressions into the `primaryParser`'s choices, enabling them to be correctly parsed as fundamental components of any expression.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e239063-f4ee-4cca-914c-af8aba68e205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e239063-f4ee-4cca-914c-af8aba68e205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

