### PR TITLE
Unify function call parsing

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -172,6 +172,28 @@ test('parses abs() calls as unary functions', () => {
   assert.equal(result.value.value.kind, 'Var');
 });
 
+test('allows built-in functions to be referenced as values', () => {
+  const result = parseFormulaInput('abs $ z');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Compose');
+  assert.equal(result.value.f.kind, 'Abs');
+  assert.equal(result.value.g.kind, 'Var');
+});
+
+test('explicit composition accepts built-in literals', () => {
+  const result = parseFormulaInput('o(abs, z)');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Compose');
+  assert.equal(result.value.f.kind, 'Abs');
+  assert.equal(result.value.g.kind, 'Var');
+});
+
+test('built-in literals work with repeat composition suffix', () => {
+  const result = parseFormulaInput('abs $$ 2');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Compose');
+});
+
 test('parses if expressions with embedded comparisons', () => {
   const result = parseFormulaInput('if(x < y, x + 1, y + 2)');
   assert.equal(result.ok, true);
@@ -194,6 +216,17 @@ test('set bindings produce scoped nodes with shared slots', () => {
   assert.equal(ast.body.right.kind, 'SetRef');
   assert.strictEqual(ast.body.left.binding, ast);
   assert.strictEqual(ast.body.right.binding, ast);
+});
+
+test('user-defined functions support call syntax f(z)', () => {
+  const result = parseFormulaInput('set f = z + 1 in f(z)');
+  assert.equal(result.ok, true);
+  const ast = result.value;
+  assert.equal(ast.kind, 'SetBinding');
+  const body = ast.body;
+  assert.equal(body.kind, 'Compose');
+  assert.equal(body.f.kind, 'SetRef');
+  assert.equal(body.g.kind, 'Var');
 });
 
 test('set bindings associate weaker than $$ and $', () => {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -219,14 +219,12 @@ test('set bindings produce scoped nodes with shared slots', () => {
 });
 
 test('user-defined functions support call syntax f(z)', () => {
-  const result = parseFormulaInput('set f = z + 1 in f(z)');
+  const result = parseFormulaInput('let f = z + 1 in f(z)');
   assert.equal(result.ok, true);
   const ast = result.value;
-  assert.equal(ast.kind, 'SetBinding');
-  const body = ast.body;
-  assert.equal(body.kind, 'Compose');
-  assert.equal(body.f.kind, 'SetRef');
-  assert.equal(body.g.kind, 'Var');
+  assert.equal(ast.kind, 'Compose');
+  assert.equal(ast.f.kind, 'Add');
+  assert.equal(ast.g.kind, 'Var');
 });
 
 test('set bindings associate weaker than $$ and $', () => {


### PR DESCRIPTION
Unify function parsing in `apps/reflex4you` to allow built-in functions as first-class callables and user-defined functions to use `f(z)` syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-24a84848-babe-456a-8091-3b8269d8328f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24a84848-babe-456a-8091-3b8269d8328f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

