### PR TITLE
Add new features and syntax

### DIFF
--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -193,8 +193,8 @@ const DEFAULT_FINGER_VALUE_MAP = {
   D1: { re: 0, im: 0 },
   D2: { re: 0, im: 0 },
   D3: { re: 0, im: 0 },
-  W1: { re: -1, im: 0 },
-  W2: { re: 1, im: 0 },
+  W1: { re: 1, im: 0 },
+  W2: { re: 0, im: 0 },
 };
 
 const fingerLiteralParsers = FINGER_TOKENS.map((label) =>

--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -29,6 +29,7 @@ function getChildEntries(node) {
     case 'Tan':
     case 'Atan':
     case 'Abs':
+    case 'Abs2':
     case 'Floor':
     case 'Conjugate':
       return [['value', node.value]];
@@ -70,6 +71,11 @@ function getChildEntries(node) {
       return [
         ['value', node.value],
         ['body', node.body],
+      ];
+    case 'RepeatComposePlaceholder':
+      return [
+        ['base', node.base],
+        ['countExpression', node.countExpression],
       ];
     case 'LetBinding':
       return [

--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -138,6 +138,10 @@ export function Abs(value) {
   return { kind: "Abs", value };
 }
 
+export function Abs2(value) {
+  return { kind: "Abs2", value };
+}
+
 export function Floor(value) {
   return { kind: "Floor", value };
 }
@@ -218,6 +222,7 @@ const formulaGlobals = Object.freeze({
   Atan,
   Ln,
   Abs,
+  Abs2,
   Floor,
   Conjugate,
   oo,
@@ -260,6 +265,7 @@ function assignNodeIds(ast) {
     case "Tan":
     case "Atan":
     case "Abs":
+    case "Abs2":
     case "Floor":
     case "Conjugate":
       assignNodeIds(ast.value);
@@ -316,6 +322,7 @@ function collectNodesPostOrder(ast, out) {
     case "Tan":
     case "Atan":
     case "Abs":
+    case "Abs2":
     case "Floor":
     case "Conjugate":
       collectNodesPostOrder(ast.value, out);
@@ -710,6 +717,16 @@ vec2 ${name}(vec2 z) {
 }`.trim();
   }
 
+  if (ast.kind === "Abs2") {
+    const valueName = functionName(ast.value);
+    return `
+vec2 ${name}(vec2 z) {
+    vec2 v = ${valueName}(z);
+    float magnitudeSquared = dot(v, v);
+    return vec2(magnitudeSquared, 0.0);
+}`.trim();
+  }
+
   if (ast.kind === "Floor") {
     const valueName = functionName(ast.value);
     return `
@@ -1039,6 +1056,9 @@ export class ReflexCore {
     this.fixedOffsetsDirty = true;
     this.dynamicOffsetsDirty = true;
     this.wOffsetsDirty = true;
+
+    this.setFingerValue('W1', -1, 0, { triggerRender: false });
+    this.setFingerValue('W2', 1, 0, { triggerRender: false });
 
     this.pointerStates = new Map();
     this.pointerSequence = 0;

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -29,6 +29,7 @@ import {
   LogicalOr,
   If,
   Abs,
+  Abs2,
   Floor,
   Conjugate,
   buildFragmentSourceFromAST,
@@ -205,6 +206,13 @@ test('Abs nodes emit magnitude as real output', () => {
   const fragment = buildFragmentSourceFromAST(ast);
   assert.match(fragment, /float magnitude = length/);
   assert.match(fragment, /vec2\(magnitude, 0\.0\)/);
+});
+
+test('Abs2 nodes emit squared magnitude as real output', () => {
+  const ast = Abs2(Const(3, 4));
+  const fragment = buildFragmentSourceFromAST(ast);
+  assert.match(fragment, /float magnitudeSquared = dot/);
+  assert.match(fragment, /vec2\(magnitudeSquared, 0\.0\)/);
 });
 
 test('Floor nodes emit component-wise floor', () => {

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -32,8 +32,18 @@ const latestOffsets = {};
 
 ALL_FINGER_LABELS.forEach((label) => {
   fingerLastSerialized[label] = null;
-  latestOffsets[label] = { x: 0, y: 0 };
+  if (label === 'W1') {
+    latestOffsets[label] = { x: -1, y: 0 };
+  } else if (label === 'W2') {
+    latestOffsets[label] = { x: 1, y: 0 };
+  } else {
+    latestOffsets[label] = { x: 0, y: 0 };
+  }
 });
+
+function getParserOptionsFromFingers() {
+  return { fingerValues: latestOffsets };
+}
 
 let activeFingerState = createEmptyFingerState();
 
@@ -96,7 +106,7 @@ function refreshFingerIndicator(label) {
 
 const DEFAULT_FORMULA_TEXT = 'z';
 
-const defaultParseResult = parseFormulaInput(DEFAULT_FORMULA_TEXT);
+const defaultParseResult = parseFormulaInput(DEFAULT_FORMULA_TEXT, getParserOptionsFromFingers());
 const fallbackDefaultAST = defaultParseResult.ok ? defaultParseResult.value : createDefaultFormulaAST();
 
 function readFormulaFromQuery() {
@@ -503,7 +513,7 @@ if (!initialFormulaSource || !initialFormulaSource.trim()) {
   initialFormulaSource = DEFAULT_FORMULA_TEXT;
 }
 
-const initialParse = parseFormulaInput(initialFormulaSource);
+const initialParse = parseFormulaInput(initialFormulaSource, getParserOptionsFromFingers());
 let initialAST;
 
 if (initialParse.ok) {
@@ -561,7 +571,7 @@ function applyFormulaFromTextarea({ updateQuery = true } = {}) {
     showError('Formula cannot be empty.');
     return;
   }
-  const result = parseFormulaInput(source);
+  const result = parseFormulaInput(source, getParserOptionsFromFingers());
   if (!result.ok) {
     showParseError(source, result);
     return;

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -33,9 +33,9 @@ const latestOffsets = {};
 ALL_FINGER_LABELS.forEach((label) => {
   fingerLastSerialized[label] = null;
   if (label === 'W1') {
-    latestOffsets[label] = { x: -1, y: 0 };
-  } else if (label === 'W2') {
     latestOffsets[label] = { x: 1, y: 0 };
+  } else if (label === 'W2') {
+    latestOffsets[label] = { x: 0, y: 0 };
   } else {
     latestOffsets[label] = { x: 0, y: 0 };
   }


### PR DESCRIPTION
Adds `abs2`, `a.b` composition syntax, and dynamic `$$` repeat counts with constant propagation to enhance formula expressiveness.

The `$$` operator now accepts any expression for its repeat count, which is evaluated during parsing using constant propagation, including current finger values. This enables more dynamic fractal definitions, such as `sin $$ (10*D1.x).floor`. Additionally, default values for W1 and W2 are set to -1 and +1 respectively.

---
<a href="https://cursor.com/background-agent?bcId=bc-56850b4a-b6c9-4ae7-ad93-5d06bb79af82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56850b4a-b6c9-4ae7-ad93-5d06bb79af82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

