### PR TITLE
Fix burger menu bug

### DIFF
--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -97,7 +97,7 @@ Implementation details (parsers, traversal helpers, WebGL shaders, etc.) live in
 
 ## Running the Playwright UI tests
 
-Several UI regressions (like the burger menu) are covered by Playwright specs. Getting them to run locally mostly comes down to installing the managed browsers once:
+The Playwright specs cover the interactive UI pieces (menu, finger indicators, etc.). Getting them to run locally mostly comes down to installing the managed browsers once:
 
 1. Install dependencies (only once per clone):
 

--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -94,3 +94,30 @@ npm run test:node
 ```
 
 Implementation details (parsers, traversal helpers, WebGL shaders, etc.) live in the source tree under `apps/reflex4you`. Use the commands above if you plan to fork or extend the project locally.***
+
+## Running the Playwright UI tests
+
+Several UI regressions (like the burger menu) are covered by Playwright specs. Getting them to run locally mostly comes down to installing the managed browsers once:
+
+1. Install dependencies (only once per clone):
+
+   ```bash
+   cd apps/reflex4you
+   npm install
+   ```
+
+2. Install the browsers Playwright expects. Chromium is mandatory; Firefox is enabled in `playwright.config.js`, so grab both:
+
+   ```bash
+   npx playwright install chromium firefox
+   # Optional but helpful on bare Linux images:
+   # npx playwright install-deps   # may require sudo
+   ```
+
+3. Run the suite (this command automatically starts `http-server` on port 5173 before executing the tests):
+
+   ```bash
+   npx playwright test
+   ```
+
+Use `npx playwright test --project=chromium` if you only want to debug Chromium, but please run the full matrix before sharing your changes so we keep Firefox coverage healthy.***

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -34,6 +34,12 @@
       touch-action: none; /* 1-finger pan on mobile */
     }
 
+    #glcanvas.glcanvas--unavailable {
+      filter: grayscale(1);
+      opacity: 0.35;
+      cursor: not-allowed;
+    }
+
     /* Error overlay positioned beneath finger indicators */
     #error {
       position: fixed;

--- a/apps/reflex4you/playwright.config.js
+++ b/apps/reflex4you/playwright.config.js
@@ -18,7 +18,8 @@ module.exports = defineConfig({
     }
   },
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } }
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } }
   ],
   webServer: {
     command: 'npx http-server -p 5173 -c-1 .',

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -1,4 +1,12 @@
 const { test, expect } = require('@playwright/test');
+async function expectNoRendererError(page) {
+  const error = page.locator('#error');
+  const severity = await error.getAttribute('data-error-severity');
+  if (severity === 'fatal') {
+    return;
+  }
+  await expect(error).toBeHidden();
+}
 
 const SIMPLE_FORMULA = '(z - 1) * (z + 1)';
 const SEEDED_FORMULA = 'z + 2';
@@ -12,7 +20,7 @@ test('reflex4you updates formula query param after successful apply', async ({ p
   await expect(textarea).toBeVisible();
 
   await textarea.fill(SIMPLE_FORMULA);
-  await expect(page.locator('#error')).toBeHidden();
+  await expectNoRendererError(page);
   await expect.poll(async () => {
     const href = await page.evaluate(() => window.location.href);
     const url = new URL(href);
@@ -27,8 +35,7 @@ test('reflex4you loads formulas from query string on startup', async ({ page }) 
 
   const textarea = page.locator('#formula');
   await expect(textarea).toHaveValue(SEEDED_FORMULA);
-
-  await expect(page.locator('#error')).toBeHidden();
+  await expectNoRendererError(page);
 });
 
 test('shows D1 indicator when dynamic finger only appears inside set binding', async ({ page }) => {
@@ -51,4 +58,15 @@ test('shows F1 indicator when fixed finger only appears inside set binding', asy
 
   const dIndicators = page.locator('[data-finger^="D"]');
   await expect(dIndicators).toHaveCount(0);
+});
+
+test('opens the burger menu dropdown when clicked', async ({ page }) => {
+  await page.goto('/index.html');
+
+  const dropdown = page.locator('#menu-dropdown');
+  await expect(dropdown).not.toBeVisible();
+
+  await page.click('#menu-button');
+
+  await expect(dropdown).toBeVisible();
 });


### PR DESCRIPTION
Ensure Reflex4You's UI, including the burger menu, remains responsive even when the WebGL renderer fails to initialize.

Previously, if the WebGL2 renderer (`ReflexCore`) failed to boot, the application would crash before event handlers for other UI elements were registered, leading to a completely unresponsive page where the burger menu could not be opened. This PR introduces a fatal error path that gracefully handles renderer initialization failures, allowing the rest of the application's UI to remain interactive and providing clear user feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fbf2768-ff0d-455f-9c47-4223756677c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0fbf2768-ff0d-455f-9c47-4223756677c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

