### PR TITLE
Add canvas recording feature

### DIFF
--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -192,6 +192,12 @@
       flex-direction: column;
       align-items: flex-end;
       pointer-events: auto;
+      transition: opacity 0.2s ease;
+    }
+
+    #menu-container.menu-container--hidden {
+      opacity: 0;
+      pointer-events: none;
     }
 
     #menu-button {
@@ -270,6 +276,77 @@
       background: rgba(255, 255, 255, 0.08);
       outline: none;
     }
+
+    @keyframes recordingPulse {
+      0% {
+        box-shadow: 0 0 0 0 rgba(255, 44, 44, 0.8);
+      }
+      70% {
+        box-shadow: 0 0 0 16px rgba(255, 44, 44, 0);
+      }
+      100% {
+        box-shadow: 0 0 0 0 rgba(255, 44, 44, 0);
+      }
+    }
+
+    #recording-control {
+      position: fixed;
+      top: calc(var(--safe-area-top) + var(--viewport-top-offset) + 12px);
+      right: 12px;
+      min-width: 140px;
+      padding: 10px 18px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      background: rgba(0, 0, 0, 0.85);
+      color: #fff;
+      font-size: 15px;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      cursor: pointer;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 45;
+      transition: background 0.15s ease, border-color 0.15s ease;
+    }
+
+    #recording-control[hidden] {
+      display: none;
+    }
+
+    #recording-control.recording-control--recording {
+      background: #c4002d;
+      border-color: rgba(255, 255, 255, 0.65);
+      animation: recordingPulse 1s ease-in-out infinite;
+    }
+
+    #recording-control.recording-control--share {
+      background: #1f5dff;
+      border-color: rgba(255, 255, 255, 0.9);
+    }
+
+    #recording-control:disabled {
+      opacity: 0.7;
+      cursor: progress;
+    }
+
+    @media (max-width: 640px) {
+      #menu-button {
+        width: 54px;
+        height: 54px;
+      }
+
+      .menu-dropdown__item {
+        font-size: 18px;
+      }
+
+      #recording-control {
+        min-width: 0;
+        width: calc(100% - 24px);
+        right: 12px;
+        left: 12px;
+      }
+    }
   </style>
 </head>
 <body>
@@ -308,8 +385,24 @@
     >
       Save image
     </button>
+    <button
+      type="button"
+      class="menu-dropdown__item"
+      data-menu-action="record"
+      role="menuitem"
+    >
+      Record video
+    </button>
   </div>
 </div>
+
+<button
+  id="recording-control"
+  type="button"
+  hidden
+  aria-live="polite"
+  aria-label="Recording control"
+></button>
 
 <div id="error"></div>
 

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -12,9 +12,16 @@ const fingerIndicatorStack = document.getElementById('finger-indicator-stack');
 const fingerOverlay = document.getElementById('finger-overlay');
 const menuButton = document.getElementById('menu-button');
 const menuDropdown = document.getElementById('menu-dropdown');
+const menuContainer = document.getElementById('menu-container');
+const recordingControlButton = document.getElementById('recording-control');
 const rootElement = typeof document !== 'undefined' ? document.documentElement : null;
 
 let fatalErrorActive = false;
+let recordingState = 'idle';
+let canvasRecorder = null;
+let canvasRecorderStream = null;
+let canvasRecorderChunks = [];
+let recordedBlob = null;
 
 const FIXED_FINGER_ORDER = ['F1', 'F2', 'F3'];
 const DYNAMIC_FINGER_ORDER = ['D1', 'D2', 'D3'];
@@ -659,6 +666,17 @@ window.addEventListener('resize', () => {
 });
 
 setupMenuInteractions();
+setRecordingState('idle');
+
+if (recordingControlButton) {
+  recordingControlButton.addEventListener('click', () => {
+    if (recordingState === 'recording') {
+      stopCanvasRecording();
+    } else if (recordingState === 'ready') {
+      void shareCurrentRecording();
+    }
+  });
+}
 
 function setupMenuInteractions() {
   if (!menuButton || !menuDropdown) {
@@ -722,6 +740,9 @@ function handleMenuAction(action) {
       break;
     case 'save-image':
       saveCanvasImage();
+      break;
+    case 'record':
+      startCanvasRecording();
       break;
     default:
       break;
@@ -798,5 +819,256 @@ function triggerImageDownload(url, filename, shouldRevoke) {
   document.body.removeChild(anchor);
   if (shouldRevoke) {
     URL.revokeObjectURL(url);
+  }
+}
+
+function chooseBestRecordingMimeType() {
+  if (typeof MediaRecorder === 'undefined' || typeof MediaRecorder.isTypeSupported !== 'function') {
+    return null;
+  }
+  const candidates = [
+    'video/mp4; codecs="avc1.42E01E,mp4a.40.2"',
+    'video/mp4',
+    'video/webm; codecs=vp9',
+    'video/webm; codecs=vp8',
+    'video/webm',
+  ];
+  for (const candidate of candidates) {
+    try {
+      if (MediaRecorder.isTypeSupported(candidate)) {
+        return candidate;
+      }
+    } catch (_) {
+      // ignore support errors
+    }
+  }
+  return null;
+}
+
+function normalizeRecordingMimeType(mime) {
+  if (!mime) {
+    return 'video/webm';
+  }
+  const base = String(mime).split(';')[0].trim();
+  return base || 'video/webm';
+}
+
+function getExtensionFromMime(mime) {
+  const base = normalizeRecordingMimeType(mime);
+  switch (base) {
+    case 'video/mp4':
+      return 'mp4';
+    case 'video/ogg':
+      return 'ogv';
+    case 'video/webm':
+    default:
+      return 'webm';
+  }
+}
+
+async function saveBlobAs(blob, suggestedName) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = suggestedName;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  try {
+    anchor.click();
+  } catch (err) {
+    console.error('Failed to trigger download', err);
+    window.open(url, '_blank');
+  } finally {
+    setTimeout(() => {
+      try {
+        document.body.removeChild(anchor);
+      } catch (_) {
+        // noop
+      }
+      try {
+        URL.revokeObjectURL(url);
+      } catch (_) {
+        // noop
+      }
+    }, 1000);
+  }
+}
+
+function canNativeShareBlob(blob, filename) {
+  try {
+    if (!navigator || typeof navigator.share !== 'function' || typeof navigator.canShare !== 'function') {
+      return false;
+    }
+    const file = new File([blob], filename, { type: blob.type || 'video/webm' });
+    return navigator.canShare({ files: [file] });
+  } catch (_) {
+    return false;
+  }
+}
+
+async function shareBlobOrSave(blob, filename) {
+  if (canNativeShareBlob(blob, filename)) {
+    const file = new File([blob], filename, { type: blob.type || 'video/webm' });
+    await navigator.share({ files: [file], title: 'Reflex4You recording' });
+    return;
+  }
+  await saveBlobAs(blob, filename);
+}
+
+function toggleMenuVisibility(shouldShow) {
+  if (!menuContainer) {
+    return;
+  }
+  menuContainer.classList.toggle('menu-container--hidden', !shouldShow);
+  if (!shouldShow) {
+    setMenuOpen(false);
+  }
+}
+
+function setRecordingState(state) {
+  recordingState = state;
+  if (!recordingControlButton) {
+    return;
+  }
+  switch (state) {
+    case 'idle':
+      recordingControlButton.hidden = true;
+      recordingControlButton.classList.remove('recording-control--recording', 'recording-control--share');
+      recordingControlButton.disabled = false;
+      recordingControlButton.textContent = '';
+      recordedBlob = null;
+      canvasRecorderChunks = [];
+      toggleMenuVisibility(true);
+      break;
+    case 'recording':
+      recordingControlButton.hidden = false;
+      recordingControlButton.classList.add('recording-control--recording');
+      recordingControlButton.classList.remove('recording-control--share');
+      recordingControlButton.disabled = false;
+      recordingControlButton.textContent = 'Stop';
+      toggleMenuVisibility(false);
+      break;
+    case 'processing':
+      recordingControlButton.hidden = false;
+      recordingControlButton.classList.remove('recording-control--recording', 'recording-control--share');
+      recordingControlButton.disabled = true;
+      recordingControlButton.textContent = 'Processing…';
+      break;
+    case 'ready':
+      recordingControlButton.hidden = false;
+      recordingControlButton.classList.remove('recording-control--recording');
+      recordingControlButton.classList.add('recording-control--share');
+      recordingControlButton.disabled = false;
+      recordingControlButton.textContent = getShareButtonLabel();
+      toggleMenuVisibility(true);
+      break;
+    default:
+      break;
+  }
+}
+
+function getShareButtonLabel() {
+  if (!recordedBlob) {
+    return 'Share recording';
+  }
+  const filename = `reflex4you-recording.${getExtensionFromMime(recordedBlob.type)}`;
+  return canNativeShareBlob(recordedBlob, filename) ? 'Share recording' : 'Download recording';
+}
+
+function startCanvasRecording() {
+  if (!canvas || typeof canvas.captureStream !== 'function') {
+    alert('Recording is not supported on this device.');
+    return;
+  }
+  if (typeof MediaRecorder === 'undefined') {
+    alert('Recording is not available in this browser.');
+    return;
+  }
+  if (recordingState !== 'idle') {
+    return;
+  }
+  try {
+    canvasRecorderStream = canvas.captureStream(60);
+  } catch (err) {
+    console.error('Failed to capture canvas stream', err);
+    alert('Unable to capture the canvas for recording.');
+    return;
+  }
+  if (!canvasRecorderStream) {
+    alert('Recording is unavailable.');
+    return;
+  }
+  const mimeType = chooseBestRecordingMimeType();
+  const options = mimeType ? { mimeType } : undefined;
+  canvasRecorderChunks = [];
+  recordedBlob = null;
+  let recorder;
+  try {
+    recorder = new MediaRecorder(canvasRecorderStream, options);
+  } catch (err) {
+    console.error('Failed to initialize recorder', err);
+    alert('Unable to start recording.');
+    return;
+  }
+  canvasRecorder = recorder;
+  recorder.ondataavailable = (event) => {
+    if (event.data && event.data.size > 0) {
+      canvasRecorderChunks.push(event.data);
+    }
+  };
+  recorder.onstop = () => {
+    try {
+      if (canvasRecorderStream) {
+        canvasRecorderStream.getTracks().forEach((track) => track.stop());
+      }
+    } catch (_) {
+      // ignore
+    }
+    canvasRecorderStream = null;
+    if (!canvasRecorderChunks.length) {
+      alert('Recording resulted in an empty file.');
+      setRecordingState('idle');
+      return;
+    }
+    const chunkType =
+      (canvasRecorderChunks.find((chunk) => chunk && chunk.type)?.type) ||
+      (recorder && recorder.mimeType) ||
+      'video/webm';
+    recordedBlob = new Blob(canvasRecorderChunks, { type: normalizeRecordingMimeType(chunkType) });
+    setRecordingState('ready');
+  };
+  recorder.start(250);
+  setRecordingState('recording');
+}
+
+function stopCanvasRecording() {
+  if (!canvasRecorder || recordingState !== 'recording') {
+    return;
+  }
+  setRecordingState('processing');
+  try {
+    canvasRecorder.stop();
+  } catch (err) {
+    console.error('Failed to stop recorder', err);
+    setRecordingState('idle');
+  } finally {
+    canvasRecorder = null;
+  }
+}
+
+async function shareCurrentRecording() {
+  if (!recordedBlob) {
+    return;
+  }
+  const filename = `reflex4you-recording-${Date.now()}.${getExtensionFromMime(recordedBlob.type)}`;
+  recordingControlButton.disabled = true;
+  try {
+    await shareBlobOrSave(recordedBlob, filename);
+  } catch (err) {
+    console.error('Unable to share recording', err);
+    alert('Unable to share or download the recording.');
+  } finally {
+    recordingControlButton.disabled = false;
+    setRecordingState('idle');
   }
 }


### PR DESCRIPTION
Implement canvas recording and sharing functionality in Reflex4You.

This PR adds a "Record video" option to the burger menu, allowing users to capture the canvas, stop recording with a blinking red button, and then share or download the resulting video. The UI is optimized for mobile, with a larger font in the burger menu and a full-width recording control.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbd3f035-a9cf-4833-96d1-b34fdd9a46b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dbd3f035-a9cf-4833-96d1-b34fdd9a46b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

