### PR TITLE
Enhance math parsing and image save

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -79,6 +79,23 @@ test('symbolic non-integer exponents remain in exp form', () => {
   assert.equal(result.value.kind, 'Exp');
 });
 
+test('power exponents beyond threshold fall back to exp form', () => {
+  const result = parseFormulaInput('z ^ 11');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Exp');
+});
+
+test('power exponents from finger-based constants collapse to Pow', () => {
+  const result = parseFormulaInput('z ^ (F1.x + 1)', {
+    fingerValues: {
+      F1: { x: 2, y: 0 },
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Pow');
+  assert.equal(result.value.exponent, 3);
+});
+
 test('parses exp/sin/cos/ln calls', () => {
   const result = parseFormulaInput('exp(sin(cos(ln(z))))');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -49,10 +49,34 @@ test('parses negative exponents', () => {
   assert.equal(result.value.exponent, -2);
 });
 
-test('rejects non-integer exponents', () => {
+test('non-integer exponents lower to exp form', () => {
   const result = parseFormulaInput('z ^ 1.5');
-  assert.equal(result.ok, false);
-  assert.match(result.message, /exponent must be an integer/i);
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Exp');
+  assert.equal(result.value.value.kind, 'Mul');
+  assert.equal(result.value.value.left.kind, 'Const');
+});
+
+test('power expressions simplify to Pow when exponent is an integer expression', () => {
+  const result = parseFormulaInput('z ^ (1 + 1)');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Pow');
+  assert.equal(result.value.exponent, 2);
+});
+
+test('set-bound integer exponent resolves to Pow', () => {
+  const result = parseFormulaInput('set n = 3 in z ^ n');
+  assert.equal(result.ok, true);
+  const binding = result.value;
+  assert.equal(binding.kind, 'SetBinding');
+  assert.equal(binding.body.kind, 'Pow');
+  assert.equal(binding.body.exponent, 3);
+});
+
+test('symbolic non-integer exponents remain in exp form', () => {
+  const result = parseFormulaInput('z ^ x');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Exp');
 });
 
 test('parses exp/sin/cos/ln calls', () => {
@@ -67,6 +91,28 @@ test('parses tan and atan calls', () => {
   assert.equal(result.ok, true);
   assert.equal(result.value.kind, 'Tan');
   assert.equal(result.value.value.kind, 'Atan');
+});
+
+test('parses arc trig aliases', () => {
+  const asinResult = parseFormulaInput('asin(z)');
+  assert.equal(asinResult.ok, true);
+  assert.equal(asinResult.value.kind, 'Asin');
+
+  const arcsinResult = parseFormulaInput('arcsin(z)');
+  assert.equal(arcsinResult.ok, true);
+  assert.equal(arcsinResult.value.kind, 'Asin');
+
+  const acosResult = parseFormulaInput('acos(z)');
+  assert.equal(acosResult.ok, true);
+  assert.equal(acosResult.value.kind, 'Acos');
+
+  const arccosResult = parseFormulaInput('arccos(z)');
+  assert.equal(arccosResult.ok, true);
+  assert.equal(arccosResult.value.kind, 'Acos');
+
+  const arctanResult = parseFormulaInput('arctan(z)');
+  assert.equal(arctanResult.ok, true);
+  assert.equal(arctanResult.value.kind, 'Atan');
 });
 
 test('parses ln calls with optional branch shift', () => {

--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -28,6 +28,8 @@ function getChildEntries(node) {
     case 'Cos':
     case 'Tan':
     case 'Atan':
+    case 'Asin':
+    case 'Acos':
     case 'Abs':
     case 'Abs2':
     case 'Floor':

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -17,6 +17,8 @@ import {
   Cos,
   Tan,
   Atan,
+  Asin,
+  Acos,
   Ln,
   oo,
   FingerOffset,
@@ -137,6 +139,13 @@ test('tan and atan nodes emit their helpers', () => {
   const fragment = buildFragmentSourceFromAST(ast);
   assert.match(fragment, /c_tan/);
   assert.match(fragment, /c_atan/);
+});
+
+test('asin and acos nodes emit their helpers', () => {
+  const ast = Asin(Acos(VarZ()));
+  const fragment = buildFragmentSourceFromAST(ast);
+  assert.match(fragment, /c_asin/);
+  assert.match(fragment, /c_acos/);
 });
 
 test('ln nodes support branch shifts via second argument', () => {


### PR DESCRIPTION
Adds full arc trigonometry support, generalizes the power operator to accept any expression, and fixes the "Save as image" functionality.

The power operator (`^`) now parses any unary-level expression as an exponent. If the exponent can be resolved to an integer (even through `set` bindings), it uses the efficient `Pow` AST node. Otherwise, it transforms `a^b` into `exp(b * ln(a))` to handle non-integer or symbolic exponents, providing broader mathematical capabilities.

The "Save as image" button was failing due to the WebGL drawing buffer not being preserved and the canvas not being fully rendered before `toBlob` was called, leading to blank or zero-byte images. This fix ensures the buffer is preserved, a fresh render is forced, and a wait for the next frame occurs before attempting to save.

---
<a href="https://cursor.com/background-agent?bcId=bc-81107383-a7b0-4d19-9369-6436799acafa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81107383-a7b0-4d19-9369-6436799acafa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

