### PR TITLE
Fix reflex4you compile error

### DIFF
--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -950,25 +950,6 @@ vec2 c_sqrt(vec2 z) {
   return vec2(realPart, imagPart);
 }
 
-vec2 c_ln_branch(vec2 z, float center);
-vec2 c_ln(vec2 z);
-
-vec2 c_asin(vec2 z) {
-  vec2 iz = vec2(-z.y, z.x);
-  vec2 one = vec2(1.0, 0.0);
-  vec2 zSquared = c_mul(z, z);
-  vec2 underSqrt = one - zSquared;
-  vec2 sqrtTerm = c_sqrt(underSqrt);
-  vec2 inside = iz + sqrtTerm;
-  vec2 lnInside = c_ln(inside);
-  return vec2(lnInside.y, -lnInside.x);
-}
-
-vec2 c_acos(vec2 z) {
-  vec2 asinValue = c_asin(z);
-  return vec2(0.5 * PI - asinValue.x, -asinValue.y);
-}
-
 float wrapAngleToRange(float angle, float center) {
   float shifted = angle - center;
   float normalized = shifted - TAU * floor((shifted + PI) / TAU);
@@ -987,6 +968,22 @@ vec2 c_ln_branch(vec2 z, float center) {
 
 vec2 c_ln(vec2 z) {
   return c_ln_branch(z, 0.0);
+}
+
+vec2 c_asin(vec2 z) {
+  vec2 iz = vec2(-z.y, z.x);
+  vec2 one = vec2(1.0, 0.0);
+  vec2 zSquared = c_mul(z, z);
+  vec2 underSqrt = one - zSquared;
+  vec2 sqrtTerm = c_sqrt(underSqrt);
+  vec2 inside = iz + sqrtTerm;
+  vec2 lnInside = c_ln(inside);
+  return vec2(lnInside.y, -lnInside.x);
+}
+
+vec2 c_acos(vec2 z) {
+  vec2 asinValue = c_asin(z);
+  return vec2(0.5 * PI - asinValue.x, -asinValue.y);
 }
 
 vec2 c_atan(vec2 z) {

--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -950,6 +950,9 @@ vec2 c_sqrt(vec2 z) {
   return vec2(realPart, imagPart);
 }
 
+vec2 c_ln_branch(vec2 z, float center);
+vec2 c_ln(vec2 z);
+
 vec2 c_asin(vec2 z) {
   vec2 iz = vec2(-z.y, z.x);
   vec2 one = vec2(1.0, 0.0);


### PR DESCRIPTION
Add GLSL forward declarations for `c_ln_branch` and `c_ln` to fix a compilation error in `apps/reflex4you`.

The `c_asin` helper function was calling `c_ln` before `c_ln` and `c_ln_branch` were defined, leading to a "no matching overloaded function found" error during shader compilation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d506dcb3-bd47-484b-8cbc-9a3d360f1181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d506dcb3-bd47-484b-8cbc-9a3d360f1181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

