### PR TITLE
Investigate parse error and add syntax

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -401,6 +401,13 @@ test('user-defined functions support call syntax f(z)', () => {
   assert.equal(ast.g.kind, 'Var');
 });
 
+test('missing "in" after let binding does not backtrack', () => {
+  const result = parseFormulaInput('let foo = z + 1 foo(z)');
+  assert.equal(result.ok, false);
+  assert.equal(result.ctor, 'SetInKeyword');
+  assert.equal(result.expected, 'in');
+});
+
 test('set bindings associate weaker than $$ and $', () => {
   const result = parseFormulaInput('set f = z $$ 2 in f $ f');
   assert.equal(result.ok, true);


### PR DESCRIPTION
Prevent parser backtracking in disjunctions when non-whitespace input has been consumed.

This ensures that parse errors are reported at the earliest relevant point, specifically fixing an issue where `let` bindings with partial values would backtrack and report errors later in the input.

---
<a href="https://cursor.com/background-agent?bcId=bc-b30536a2-2c5d-4cc2-a011-748b2276c9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b30536a2-2c5d-4cc2-a011-748b2276c9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

