### PR TITLE
Fix $$ constant detection

### DIFF
--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -63,6 +63,11 @@ function getChildEntries(node) {
         ['f', node.f],
         ['g', node.g],
       ];
+    case 'ComposeMultiple':
+      return [
+        ['base', node.base],
+        ['countExpression', node.countExpression],
+      ];
     case 'If':
       return [
         ['condition', node.condition],


### PR DESCRIPTION
Introduce a `ComposeMultiple` AST node for `$$` expressions to defer expansion, enabling correct finger constant detection in RHS and supporting zero counts as identity.

Previously, `$$` immediately duplicated the left-hand side definition, losing the original `countExpression` and preventing analysis tools from seeing finger constants like `D1` if they were part of the count. By introducing `ComposeMultiple`, the original `countExpression` is preserved in the AST, and the expansion into multiple `Compose` nodes is deferred until just before shader generation, allowing for proper AST traversal and analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb04c0c2-e54b-43f6-89b8-400316df6a4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb04c0c2-e54b-43f6-89b8-400316df6a4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

