### PR TITLE
Pr preview deployments

### DIFF
--- a/.github/workflows/pages-production.yml
+++ b/.github/workflows/pages-production.yml
@@ -1,0 +1,33 @@
+name: Deploy production (GitHub Pages)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy main to gh-pages root
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # This repo is a static site (HTML/JS/CSS). If you later add a build step,
+      # insert it here and set `folder:` below to your build output directory.
+
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: .
+          enable_jekyll: false
+          clean: true
+          single-commit: true

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,71 @@
+name: PR Preview Cleanup (GitHub Pages)
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pr-preview-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Remove PR preview folder from gh-pages
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Check if gh-pages branch exists
+        id: ghpages
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.repos.getBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: "gh-pages",
+              });
+              core.setOutput("exists", "true");
+            } catch (e) {
+              core.setOutput("exists", "false");
+            }
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        if: steps.ghpages.outputs.exists == 'true'
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+
+      - name: Delete preview folder (if present)
+        if: steps.ghpages.outputs.exists == 'true'
+        run: |
+          set -euo pipefail
+          PREVIEW_DIR="pr-preview/pr-${{ github.event.pull_request.number }}"
+          if [ -d "$PREVIEW_DIR" ]; then
+            rm -rf "$PREVIEW_DIR"
+            echo "Deleted $PREVIEW_DIR"
+          else
+            echo "No preview folder to delete: $PREVIEW_DIR"
+          fi
+
+      - name: Commit & push (if changed)
+        if: steps.ghpages.outputs.exists == 'true'
+        run: |
+          set -euo pipefail
+          if git status --porcelain | grep -q .; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "chore: cleanup PR preview #${{ github.event.pull_request.number }}"
+            git push
+          else
+            echo "No changes to commit."
+          fi
+
+      - name: Nothing to clean up (no gh-pages branch yet)
+        if: steps.ghpages.outputs.exists != 'true'
+        run: echo "gh-pages branch does not exist; skipping cleanup."

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,60 @@
+name: PR Preview (GitHub Pages)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy_preview:
+    name: Deploy PR preview to gh-pages subfolder
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      # Static site: deploy repo contents as-is.
+      # If you later add a build step, build here and deploy the build output folder.
+
+      - name: Deploy preview to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: .
+          target-folder: pr-preview/pr-${{ github.event.pull_request.number }}
+          clean: true
+          single-commit: false
+
+      - name: Comment preview URL on PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ✅ **PR Preview deployed**
+
+            - **Preview URL**: https://${{ github.repository_owner }}.github.io/pr-preview/pr-${{ github.event.pull_request.number }}/
+            - **Commit**: ${{ github.event.pull_request.head.sha }}
+
+  no_preview_for_forks:
+    name: Inform forks that previews are disabled
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Comment why preview is skipped
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ⚠️ **PR Preview not deployed**
+
+            This PR comes from a fork, so GitHub restricts `GITHUB_TOKEN` permissions and the workflow cannot publish to `gh-pages`.

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 concurrency:
@@ -17,28 +17,42 @@ jobs:
     name: Deploy PR preview to gh-pages subfolder
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      # Static site: deploy repo contents as-is.
+      # Static site: deploy this app as-is.
       # If you later add a build step, build here and deploy the build output folder.
 
       - name: Deploy preview to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: .
+          folder: apps/reflex4you
           target-folder: pr-preview/pr-${{ github.event.pull_request.number }}
+          enable_jekyll: false
           clean: true
           single-commit: false
 
       - name: Comment preview URL on PR
+        id: preview-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "PR Preview deployed"
+
+      - name: Create or update PR comment with preview URL
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.preview-comment.outputs.comment-id }}
+          edit-mode: replace
           body: |
             ✅ **PR Preview deployed**
 
@@ -49,11 +63,23 @@ jobs:
     name: Inform forks that previews are disabled
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name != github.repository
+    permissions:
+      pull-requests: write
     steps:
-      - name: Comment why preview is skipped
+      - name: Find existing "skipped" comment
+        id: skipped-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "PR Preview not deployed"
+
+      - name: Create or update comment why preview is skipped
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.skipped-comment.outputs.comment-id }}
+          edit-mode: replace
           body: |
             ⚠️ **PR Preview not deployed**
 


### PR DESCRIPTION
Add GitHub Actions workflows for GitHub Pages production deployment and PR previews for `apps/reflex4you`.

This enables testing of `apps/reflex4you` changes on unique preview URLs for each PR, provides automatic cleanup, and manages the main branch deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ca3fae2-fca3-4cb4-b0aa-13e670530725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ca3fae2-fca3-4cb4-b0aa-13e670530725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

