### PR TITLE
Gpu negative number computation

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -253,21 +253,11 @@ test('$$ accepts parenthesized expressions with constant propagation', () => {
 test('$$ accepts bare additive expressions on the right-hand side', () => {
   const result = parseFormulaInput('z $$ 2 + 3');
   assert.equal(result.ok, true);
-  assert.equal(result.value.kind, 'Compose');
-  const stack = [result.value];
-  let varCount = 0;
-  while (stack.length) {
-    const node = stack.pop();
-    if (!node || typeof node !== 'object') {
-      continue;
-    }
-    if (node.kind === 'Compose') {
-      stack.push(node.f, node.g);
-    } else if (node.kind === 'Var') {
-      varCount += 1;
-    }
-  }
-  assert.equal(varCount, 5);
+  // `$$` binds tighter than `+`, and the parser keeps a compact `ComposeMultiple`
+  // node (later materialized by the engine when building the shader).
+  assert.equal(result.value.kind, 'ComposeMultiple');
+  assert.equal(result.value.resolvedCount, 5);
+  assert.equal(result.value.base.kind, 'Var');
 });
 
 test('$$ can derive counts from finger values', () => {

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -73,6 +73,8 @@ test('fragment generator embeds node functions and top entry', () => {
   assert.match(fragment, /vec2 node\d+\(vec2 z\)/);
   assert.match(fragment, /vec2 f\(vec2 z\)/);
   assert.match(fragment, /return node\d+\(z\);/);
+  // Guard against rare GPU/driver divide-by-zero on strictly negative reals.
+  assert.match(fragment, /if\s*\(im == 0\.0 && re < 0\.0\)/);
 });
 
 test('Pow nodes emit exponentiation by squaring and allow negatives', () => {


### PR DESCRIPTION
Add a shader shortcut for strictly negative real numbers to prevent division-by-zero errors.

Some GPUs/drivers can underflow tiny denominators to 0.0 in the "negative real axis" case, leading to division-by-zero and NaNs in the final color. This PR adds a fast path for `im == 0.0 && re < 0.0` to avoid evaluating denominator-based formulas in that specific case.

An existing parser test was also updated to reflect the `ComposeMultiple` AST node, which is consistent with other `$$` tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c82cd6f-d740-4b25-8f98-2e3f94395f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c82cd6f-d740-4b25-8f98-2e3f94395f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

