### PR TITLE
Pwa reflex link sharing

### DIFF
--- a/apps/reflex4you/formula-url.mjs
+++ b/apps/reflex4you/formula-url.mjs
@@ -1,8 +1,23 @@
 const FORMULA_PARAM = 'formula';
 const FORMULA_B64_PARAM = 'formulab64';
+const LAST_STATE_SEARCH_KEY = 'reflex4you:lastSearch';
 
 const sharedTextEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
 const sharedTextDecoder = typeof TextDecoder !== 'undefined' ? new TextDecoder() : null;
+
+function persistSearchToLocalStorage(search, env = {}) {
+  const storage =
+    env.localStorage ??
+    (typeof window !== 'undefined' ? window.localStorage : null);
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(LAST_STATE_SEARCH_KEY, String(search || ''));
+  } catch (_) {
+    // Ignore storage failures (private mode, quota, etc.).
+  }
+}
 
 function getWindowSecureContextFlag() {
   if (typeof window === 'undefined') {
@@ -205,6 +220,7 @@ export function replaceUrlSearch(params, env = {}) {
   const newQuery = params.toString();
   const newUrl = `${location.pathname}${newQuery ? `?${newQuery}` : ''}`;
   history.replaceState({}, '', newUrl);
+  persistSearchToLocalStorage(newQuery ? `?${newQuery}` : '', env);
 }
 
 async function upgradeLegacyFormulaParam(source, env = {}) {
@@ -284,4 +300,4 @@ export function updateFormulaQueryParamImmediately(source, options = {}) {
   replaceUrlSearch(params, options);
 }
 
-export { FORMULA_PARAM, FORMULA_B64_PARAM };
+export { FORMULA_PARAM, FORMULA_B64_PARAM, LAST_STATE_SEARCH_KEY };

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -331,6 +331,14 @@
     <button
       type="button"
       class="menu-dropdown__item"
+      data-menu-action="copy-share-link"
+      role="menuitem"
+    >
+      Copy share link
+    </button>
+    <button
+      type="button"
+      class="menu-dropdown__item"
       data-menu-action="reset"
       role="menuitem"
     >

--- a/apps/reflex4you/manifest.json
+++ b/apps/reflex4you/manifest.json
@@ -2,9 +2,14 @@
   "name": "Reflex4You",
   "short_name": "Reflex4You",
   "description": "Interactive complex-function explorer with gesture-driven handles.",
-  "start_url": ".",
-  "scope": ".",
+  "id": "/apps/reflex4you/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
+  "launch_handler": {
+    "client_mode": ["navigate-existing", "auto"]
+  },
+  "handle_links": "preferred",
   "orientation": "any",
   "background_color": "#000000",
   "theme_color": "#000000",

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -223,6 +223,21 @@ test('menu can copy a share link for the current reflex', async ({ page }) => {
   }
 });
 
+test('pwa relaunch restores last reflex when opened without query string', async ({ page }) => {
+  await page.goto('/index.html');
+  await waitForReflexReady(page);
+
+  const textarea = page.locator('#formula');
+  await expect(textarea).toBeVisible();
+  await textarea.fill(SIMPLE_FORMULA);
+  await expectNoRendererError(page);
+
+  // Simulate a PWA relaunch that goes to the bare start_url without query params.
+  await page.goto('/index.html');
+  await waitForReflexReady(page);
+  await expect(page.locator('#formula')).toHaveValue(SIMPLE_FORMULA);
+});
+
 test('re-runs parse/desugar pipeline when D1 changes for $$ repeat counts', async ({ page }) => {
   await page.goto('/index.html');
   await waitForReflexReady(page);

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -179,6 +179,50 @@ test('opens the burger menu dropdown when clicked', async ({ page }) => {
   await expect(dropdown).toBeVisible();
 });
 
+test('menu can copy a share link for the current reflex', async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (text) => {
+          window.__copiedText = String(text);
+        },
+      },
+    });
+  });
+
+  await page.goto('/index.html');
+  await waitForReflexReady(page);
+
+  const textarea = page.locator('#formula');
+  await expect(textarea).toBeVisible();
+  await textarea.fill(SIMPLE_FORMULA);
+  await expectNoRendererError(page);
+
+  await page.click('#menu-button');
+  await page.click('[data-menu-action="copy-share-link"]');
+
+  await expect.poll(async () => {
+    return await page.evaluate(() => window.__copiedText || null);
+  }).not.toBeNull();
+
+  const params = await page.evaluate(() => {
+    const url = new URL(window.__copiedText);
+    return {
+      base64: url.searchParams.get('formulab64'),
+      legacy: url.searchParams.get('formula'),
+      edit: url.searchParams.get('edit'),
+    };
+  });
+
+  expect(params.edit).toBeNull();
+  if (params.base64) {
+    expect(decodeFormulab64(params.base64)).toBe(SIMPLE_FORMULA);
+  } else {
+    expect(params.legacy).toBe(SIMPLE_FORMULA);
+  }
+});
+
 test('re-runs parse/desugar pipeline when D1 changes for $$ repeat counts', async ({ page }) => {
   await page.goto('/index.html');
   await waitForReflexReady(page);


### PR DESCRIPTION
Add a "Copy share link" menu item to the Reflex4You PWA to enable sharing of the current reflex state via a URL.

This allows users to easily generate a canonical, absolute URL for their current reflex, which can then be opened directly in the PWA to restore the exact state. The shared link defaults to viewer mode and uses `formulab64` for efficient encoding when supported.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e340ebe-f4d1-4573-991e-cc9606344e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e340ebe-f4d1-4573-991e-cc9606344e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

