### PR TITLE
Bug investigation calculation issue

### DIFF
--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -934,6 +934,12 @@ function substitutePlaceholder(node, placeholder, replacement) {
     case 'Identifier':
     case 'SetRef':
       return cloneAst(node);
+    case 'LetBinding':
+      return {
+        ...node,
+        value: substitutePlaceholder(node.value, placeholder, replacement),
+        body: substitutePlaceholder(node.body, placeholder, replacement),
+      };
     case 'Pow':
       return { ...node, base: substitutePlaceholder(node.base, placeholder, replacement) };
     case 'Exp':
@@ -1023,6 +1029,12 @@ function cloneAst(node) {
     case 'Identifier':
     case 'SetRef':
       return { ...node };
+    case 'LetBinding':
+      return {
+        ...node,
+        value: cloneAst(node.value),
+        body: cloneAst(node.body),
+      };
     case 'SetBinding':
       return {
         ...node,
@@ -1115,6 +1127,18 @@ function substituteIdentifierWithClone(node, targetName, replacement) {
     case 'PlaceholderVar':
     case 'SetRef':
       return cloneAst(node);
+    case 'LetBinding': {
+      const nextValue = substituteIdentifierWithClone(node.value, targetName, replacement);
+      const nextBody =
+        node.name === targetName
+          ? cloneAst(node.body)
+          : substituteIdentifierWithClone(node.body, targetName, replacement);
+      return {
+        ...node,
+        value: nextValue,
+        body: nextBody,
+      };
+    }
     case 'Pow':
       return { ...node, base: substituteIdentifierWithClone(node.base, targetName, replacement) };
     case 'Exp':

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -497,6 +497,14 @@ test('nested let bindings are rejected', () => {
   assert.match(result.message, /top level/i);
 });
 
+test('top-level let can be followed by another let (sequential lets)', () => {
+  const source = `let zeroline = heav $ 0.05-z $ abs in
+let f = y - 3*sin(3*x) in
+zeroline $ f`;
+  const result = parseFormulaInput(source);
+  assert.equal(result.ok, true);
+});
+
 test('parseFormulaToAST throws on invalid formula', () => {
   assert.throws(() => parseFormulaToAST('('), {
     name: 'SyntaxError',


### PR DESCRIPTION
Fixes a parser crash when handling sequential `let` bindings, which previously caused silent failures in the UI.

The parser would throw an `Error: Unknown AST kind in cloneAst: LetBinding` exception when a top-level `let`'s body started with another `let`. This exception was not caught by the UI, resulting in no error message and no update. This PR fixes the parser to correctly handle `LetBinding` nodes during cloning and substitution, allowing valid sequential `let` expressions to parse and evaluate normally.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d8a6e37-0ff9-4183-a4dc-e4404cab60b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1d8a6e37-0ff9-4183-a4dc-e4404cab60b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

