### PR TITLE
PWA color and parsing bugs

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -50,6 +50,24 @@ test('parses negative exponents', () => {
   assert.equal(result.value.exponent, -2);
 });
 
+test('unary minus binds weaker than exponentiation', () => {
+  const result = parseFormulaInput('-z^4');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Sub');
+  assert.equal(result.value.left.kind, 'Const');
+  assert.equal(result.value.right.kind, 'Pow');
+  assert.equal(result.value.right.base.kind, 'Var');
+  assert.equal(result.value.right.exponent, 4);
+});
+
+test('parentheses can force (-z)^4', () => {
+  const result = parseFormulaInput('(-z)^4');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Pow');
+  assert.equal(result.value.exponent, 4);
+  assert.equal(result.value.base.kind, 'Sub');
+});
+
 test('non-integer exponents lower to exp form', () => {
   const result = parseFormulaInput('z ^ 1.5');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -74,7 +74,7 @@ test('fragment generator embeds node functions and top entry', () => {
   assert.match(fragment, /vec2 f\(vec2 z\)/);
   assert.match(fragment, /return node\d+\(z\);/);
   // Guard against rare GPU/driver divide-by-zero on strictly negative reals.
-  assert.match(fragment, /if\s*\(im == 0\.0 && re < 0\.0\)/);
+  assert.match(fragment, /if\s*\(re < 0\.0 && denRaw <= COLOR_MIN_DEN\)/);
 });
 
 test('Pow nodes emit exponentiation by squaring and allow negatives', () => {


### PR DESCRIPTION
Fixes unary minus precedence (`-z^4` parses as `-(z^4)`) and a PWA-only negative real axis coloring bug.

The parser's grammar incorrectly prioritized unary minus over exponentiation, causing `-z^4` to be interpreted as `(-z)^4`. This PR reorders precedence to `-(z^4)`. Additionally, a PWA-only coloring bug on the negative real axis was due to the shader's `im == 0.0` check being unreliable; it now uses `denRaw <= COLOR_MIN_DEN` for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-44c08095-9aac-45f0-bf73-7e70064ed636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-44c08095-9aac-45f0-bf73-7e70064ed636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

