### PR TITLE
Finger constant support extension

### DIFF
--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -227,23 +227,48 @@ const literalParser = Choice([
   jLiteral,
 ], { ctor: 'Literal' });
 
-const FINGER_TOKENS = ['F1', 'F2', 'F3', 'D1', 'D2', 'D3', 'W1', 'W2'];
+const FINGER_LABEL_REGEX = /(?:[FD][1-9]\d*|W[12])/y;
 
-const DEFAULT_FINGER_VALUE_MAP = {
-  F1: { re: 0, im: 0 },
-  F2: { re: 0, im: 0 },
-  F3: { re: 0, im: 0 },
-  D1: { re: 0, im: 0 },
-  D2: { re: 0, im: 0 },
-  D3: { re: 0, im: 0 },
-  W1: { re: 1, im: 0 },
-  W2: { re: 0, im: 0 },
-};
+function isFingerLabel(label) {
+  if (!label || typeof label !== 'string') {
+    return false;
+  }
+  if (label === 'W1' || label === 'W2') {
+    return true;
+  }
+  return /^[FD][1-9]\d*$/.test(label);
+}
 
-const fingerLiteralParsers = FINGER_TOKENS.map((label) =>
-  keywordLiteral(label, { ctor: `Finger(${label})` }).Map((_, result) =>
-    withSyntax(withSpan(FingerOffset(label), result.span), label),
-  ),
+const fingerToken = wsRegex(FINGER_LABEL_REGEX, {
+  ctor: 'FingerToken',
+  transform: (match) => match[0],
+});
+
+const fingerLiteralParser = createParser('FingerLiteral', (input) => {
+  const result = fingerToken.runNormalized(input);
+  if (!result.ok) {
+    return result;
+  }
+  const nextChar = result.next.peek();
+  if (nextChar && IDENTIFIER_CHAR.test(nextChar)) {
+    // e.g. "F1foo" should be parsed as an identifier, not a finger literal.
+    return new ParseFailure({
+      ctor: 'FingerLiteral',
+      message: 'Expected finger literal',
+      severity: ParseSeverity.recoverable,
+      expected: 'finger literal',
+      span: result.span,
+      input: result.span.input,
+    });
+  }
+  return new ParseSuccess({
+    ctor: 'FingerLiteral',
+    value: result.value,
+    span: result.span,
+    next: result.next,
+  });
+}).Map((label, result) =>
+  withSyntax(withSpan(FingerOffset(label), result.span), label),
 );
 
 const RESERVED_BINDING_NAMES = new Set([
@@ -277,7 +302,6 @@ const RESERVED_BINDING_NAMES = new Set([
   'z',
   'j',
   ITERATION_VARIABLE_NAME,
-  ...FINGER_TOKENS,
 ]);
 
 const iterationVariableLiteral = keywordLiteral(ITERATION_VARIABLE_NAME, { ctor: 'IterationVar' })
@@ -309,7 +333,7 @@ const bindingIdentifierParser = createParser('BindingIdentifier', (input) => {
   if (!identifier.ok) {
     return identifier;
   }
-  if (RESERVED_BINDING_NAMES.has(identifier.value)) {
+  if (RESERVED_BINDING_NAMES.has(identifier.value) || isFingerLabel(identifier.value)) {
     return new ParseFailure({
       ctor: 'BindingIdentifier',
       message: `"${identifier.value}" is a reserved identifier and cannot be bound with set`,
@@ -333,7 +357,7 @@ const primitiveParser = Choice([
   keywordLiteral('real', { ctor: 'VarReal' }).Map((_, result) => withSyntax(withSpan(VarX(), result.span), 'real')),
   keywordLiteral('imag', { ctor: 'VarImag' }).Map((_, result) => withSyntax(withSpan(VarY(), result.span), 'imag')),
   keywordLiteral('z', { ctor: 'VarZ' }).Map((_, result) => withSpan(VarZ(), result.span)),
-  ...fingerLiteralParsers,
+  fingerLiteralParser,
   iterationVariableLiteral,
   identifierReferenceParser,
 ], { ctor: 'Primitive' });
@@ -1550,7 +1574,7 @@ function normalizeParseOptions(options = {}) {
 }
 
 function normalizeFingerValuesSource(source) {
-  const map = createDefaultFingerValueMap();
+  const map = new Map();
   if (!source) {
     return map;
   }
@@ -1568,17 +1592,8 @@ function normalizeFingerValuesSource(source) {
   return map;
 }
 
-function createDefaultFingerValueMap() {
-  const map = new Map();
-  FINGER_TOKENS.forEach((label) => {
-    const defaults = DEFAULT_FINGER_VALUE_MAP[label] || { re: 0, im: 0 };
-    map.set(label, { re: defaults.re, im: defaults.im });
-  });
-  return map;
-}
-
 function assignFingerValue(map, label, value) {
-  if (!FINGER_TOKENS.includes(label)) {
+  if (!isFingerLabel(label)) {
     return;
   }
   const normalized = normalizeComplexInput(value);
@@ -2077,10 +2092,15 @@ function evaluateComparison(kind, left, right) {
 
 function getFingerValueFromContext(label, fingerValues) {
   const value = fingerValues?.get(label);
-  if (!value) {
-    return null;
+  if (value) {
+    return { re: value.re, im: value.im };
   }
-  return { re: value.re, im: value.im };
+  // Default missing finger values to 0 (with W1 defaulting to 1+0i),
+  // matching the previous fixed-token behavior.
+  if (label === 'W1') {
+    return { re: 1, im: 0 };
+  }
+  return { re: 0, im: 0 };
 }
 
 function complexAdd(a, b) {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -195,6 +195,22 @@ test('parses additional finger primitives', () => {
   assert.equal(add.right.slot, 'D3');
 });
 
+test('parses non-consecutive finger primitives (any F*/D*)', () => {
+  const result = parseFormulaInput('F7 + D12');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Add');
+  assert.equal(result.value.left.kind, 'FingerOffset');
+  assert.equal(result.value.left.slot, 'F7');
+  assert.equal(result.value.right.kind, 'FingerOffset');
+  assert.equal(result.value.right.slot, 'D12');
+});
+
+test('rejects binding finger names with set', () => {
+  const result = parseFormulaInput('set F7 = 1 in F7');
+  assert.equal(result.ok, false);
+  assert.match(result.message, /reserved identifier/i);
+});
+
 test('parses W finger primitives', () => {
   const result = parseFormulaInput('W1 + W2');
   assert.equal(result.ok, true);
@@ -261,9 +277,9 @@ test('$$ accepts bare additive expressions on the right-hand side', () => {
 });
 
 test('$$ can derive counts from finger values', () => {
-  const result = parseFormulaInput('sin $$ (10 * D1.x).floor', {
+  const result = parseFormulaInput('sin $$ (10 * D12.x).floor', {
     fingerValues: {
-      D1: { x: 0.5, y: 0 },
+      D12: { x: 0.5, y: 0 },
     },
   });
   assert.equal(result.ok, true);
@@ -272,7 +288,7 @@ test('$$ can derive counts from finger values', () => {
   assert.equal(result.value.base.kind, 'Sin');
   let fingerSeen = false;
   visitAst(result.value.countExpression, (node) => {
-    if (node.kind === 'FingerOffset' && node.slot === 'D1') {
+    if (node.kind === 'FingerOffset' && node.slot === 'D12') {
       fingerSeen = true;
     }
   });

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -87,14 +87,14 @@ test('Pow nodes emit exponentiation by squaring and allow negatives', () => {
 test('Offset2 nodes read from the fixed offset array', () => {
   const ast = Offset2();
   const fragment = buildFragmentSourceFromAST(ast);
-  assert.match(fragment, /uniform vec2 u_fixedOffsets\[3\]/);
+  assert.match(fragment, /uniform vec2 u_fixedOffsets\[2\]/);
   assert.match(fragment, /return u_fixedOffsets\[1\];/);
 });
 
 test('dynamic fingers read from the dynamic offset array', () => {
   const ast = FingerOffset('D1');
   const fragment = buildFragmentSourceFromAST(ast);
-  assert.match(fragment, /uniform vec2 u_dynamicOffsets\[3\]/);
+  assert.match(fragment, /uniform vec2 u_dynamicOffsets\[1\]/);
   assert.match(fragment, /return u_dynamicOffsets\[0\];/);
 });
 

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -98,6 +98,18 @@ test('dynamic fingers read from the dynamic offset array', () => {
   assert.match(fragment, /return u_dynamicOffsets\[0\];/);
 });
 
+test('supports sparse high-index finger uniforms', () => {
+  const fixedAst = FingerOffset('F7');
+  const fixedFragment = buildFragmentSourceFromAST(fixedAst);
+  assert.match(fixedFragment, /uniform vec2 u_fixedOffsets\[7\]/);
+  assert.match(fixedFragment, /return u_fixedOffsets\[6\];/);
+
+  const dynamicAst = FingerOffset('D12');
+  const dynamicFragment = buildFragmentSourceFromAST(dynamicAst);
+  assert.match(dynamicFragment, /uniform vec2 u_dynamicOffsets\[12\]/);
+  assert.match(dynamicFragment, /return u_dynamicOffsets\[11\];/);
+});
+
 test('W fingers read from the W offset array', () => {
   const ast = FingerOffset('W2');
   const fragment = buildFragmentSourceFromAST(ast);

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -29,7 +29,7 @@ const rootElement = typeof document !== 'undefined' ? document.documentElement :
 
 let fatalErrorActive = false;
 
-const APP_VERSION = 3;
+const APP_VERSION = 4;
 
 if (versionPill) {
   versionPill.textContent = `v${APP_VERSION}`;

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -41,43 +41,120 @@ const ANIMATION_TIME_PARAM = 't';
 
 const DEFAULT_ANIMATION_SECONDS = 5;
 
-const FIXED_FINGER_ORDER = ['F1', 'F2', 'F3'];
-const DYNAMIC_FINGER_ORDER = ['D1', 'D2', 'D3'];
 const W_FINGER_ORDER = ['W1', 'W2'];
-const ALL_FINGER_LABELS = [...FIXED_FINGER_ORDER, ...DYNAMIC_FINGER_ORDER, ...W_FINGER_ORDER];
-const DEFAULT_FINGER_OFFSETS = Object.freeze(
-  ALL_FINGER_LABELS.reduce((acc, label) => {
-    const value = label === 'W1' ? { x: 1, y: 0 } : { x: 0, y: 0 };
-    acc[label] = Object.freeze(value);
-    return acc;
-  }, {}),
-);
+const FINGER_LABEL_REGEX = /^(?:[FD][1-9]\d*|W[12])$/;
 
-function cloneFingerOffsets(source) {
-  const clone = {};
-  ALL_FINGER_LABELS.forEach((label) => {
-    const baseline = source[label] || { x: 0, y: 0 };
-    clone[label] = { x: baseline.x, y: baseline.y };
-  });
-  return clone;
+function isFingerLabel(label) {
+  return typeof label === 'string' && FINGER_LABEL_REGEX.test(label);
 }
 
-const FINGER_METADATA = ALL_FINGER_LABELS.reduce((acc, label) => {
-  acc[label] = {
+function fingerFamily(label) {
+  if (!label) return null;
+  if (label.startsWith('F')) return 'fixed';
+  if (label.startsWith('D')) return 'dynamic';
+  if (label.startsWith('W')) return 'w';
+  return null;
+}
+
+function fingerIndex(label) {
+  if (!label) return -1;
+  if (label === 'W1') return 0;
+  if (label === 'W2') return 1;
+  const match = /^([FD])([1-9]\d*)$/.exec(label);
+  if (!match) return -1;
+  return Number(match[2]) - 1;
+}
+
+function defaultFingerOffset(label) {
+  if (label === 'W1') {
+    return { x: 1, y: 0 };
+  }
+  return { x: 0, y: 0 };
+}
+
+function getFingerMeta(label) {
+  return {
     label,
-    type: label.startsWith('F') ? 'fixed' : label.startsWith('D') ? 'dynamic' : 'w',
+    type: fingerFamily(label) || 'fixed',
   };
-  return acc;
-}, {});
+}
+
+function sortFingerLabels(labels) {
+  return labels
+    .slice()
+    .filter((label) => isFingerLabel(label))
+    .sort((a, b) => {
+      const fa = fingerFamily(a);
+      const fb = fingerFamily(b);
+      if (fa !== fb) {
+        // Keep fixed/dynamic ahead of workspace.
+        if (fa === 'w') return 1;
+        if (fb === 'w') return -1;
+      }
+      return fingerIndex(a) - fingerIndex(b);
+    });
+}
 
 const fingerIndicators = new Map();
 const fingerDots = new Map();
 const fingerLastSerialized = {};
-const latestOffsets = cloneFingerOffsets(DEFAULT_FINGER_OFFSETS);
+const latestOffsets = {};
+const knownFingerLabels = new Set();
+const fingerUnsubscribers = new Map();
 
-ALL_FINGER_LABELS.forEach((label) => {
-  fingerLastSerialized[label] = null;
-});
+function ensureFingerState(label) {
+  if (!isFingerLabel(label)) {
+    return;
+  }
+  knownFingerLabels.add(label);
+  if (!latestOffsets[label]) {
+    latestOffsets[label] = defaultFingerOffset(label);
+  }
+  if (!(label in fingerLastSerialized)) {
+    fingerLastSerialized[label] = null;
+  }
+}
+
+// Always keep workspace fingers in a known state.
+W_FINGER_ORDER.forEach((label) => ensureFingerState(label));
+
+function ensureFingerSubscriptions(labels) {
+  if (!reflexCore) {
+    return;
+  }
+  (labels || []).forEach((label) => {
+    if (!isFingerLabel(label)) {
+      return;
+    }
+    ensureFingerState(label);
+    if (fingerUnsubscribers.has(label)) {
+      return;
+    }
+    const unsubscribe = reflexCore.onFingerChange(label, (offset) => handleFingerValueChange(label, offset));
+    fingerUnsubscribers.set(label, unsubscribe);
+  });
+}
+
+function applyFingerValuesFromQuery(labels) {
+  if (!reflexCore) {
+    return;
+  }
+  suppressFingerQueryUpdates = true;
+  try {
+    (labels || []).forEach((label) => {
+      if (!isFingerLabel(label)) {
+        return;
+      }
+      const parsed = readFingerFromQuery(label);
+      if (parsed) {
+        reflexCore.setFingerValue(label, parsed.x, parsed.y, { triggerRender: false });
+      }
+    });
+  } finally {
+    suppressFingerQueryUpdates = false;
+  }
+  reflexCore.render();
+}
 
 function getParserOptionsFromFingers() {
   return { fingerValues: latestOffsets };
@@ -144,6 +221,7 @@ function setupViewportInsetListeners() {
 setupViewportInsetListeners();
 
 function refreshFingerIndicator(label) {
+  ensureFingerState(label);
   const indicator = fingerIndicators.get(label);
   if (!indicator) {
     return;
@@ -393,7 +471,8 @@ function ensureFingerIndicator(label) {
   if (fingerIndicators.has(label)) {
     return fingerIndicators.get(label);
   }
-  const meta = FINGER_METADATA[label];
+  ensureFingerState(label);
+  const meta = getFingerMeta(label);
   const indicator = document.createElement('button');
   indicator.type = 'button';
   indicator.className = `finger-indicator finger-indicator--${meta.type}`;
@@ -411,7 +490,8 @@ function ensureFingerDot(label) {
   if (fingerDots.has(label)) {
     return fingerDots.get(label);
   }
-  const meta = FINGER_METADATA[label];
+  ensureFingerState(label);
+  const meta = getFingerMeta(label);
   const dot = document.createElement('div');
   dot.className = `finger-dot finger-dot--${meta.type}`;
   dot.dataset.fingerDot = label;
@@ -511,6 +591,7 @@ function clearFingerQueryParam(label) {
 }
 
 function handleFingerValueChange(label, offset) {
+  ensureFingerState(label);
   latestOffsets[label] = { x: offset.x, y: offset.y };
   refreshFingerIndicator(label);
   updateFingerDotPosition(label);
@@ -628,8 +709,8 @@ function resolveAxisContext(parent, node) {
 }
 
 function deriveFingerState(analysis) {
-  const fixedSlots = FIXED_FINGER_ORDER.filter((label) => analysis.usage.fixed.has(label));
-  const dynamicSlots = DYNAMIC_FINGER_ORDER.filter((label) => analysis.usage.dynamic.has(label));
+  const fixedSlots = sortFingerLabels(Array.from(analysis.usage.fixed));
+  const dynamicSlots = sortFingerLabels(Array.from(analysis.usage.dynamic));
   const wSlots = W_FINGER_ORDER.filter((label) => analysis.usage.w.has(label));
   if (fixedSlots.length && dynamicSlots.length) {
     return {
@@ -638,7 +719,7 @@ function deriveFingerState(analysis) {
       dynamicSlots: [],
       wSlots: [],
       axisConstraints: new Map(),
-      error: 'Formulas cannot mix F fingers (F1..F3) with D fingers (D1..D3).',
+      error: 'Formulas cannot mix F* fingers with D* fingers.',
     };
   }
   const mode = fixedSlots.length ? 'fixed' : dynamicSlots.length ? 'dynamic' : 'none';
@@ -693,6 +774,7 @@ function applyFingerState(state) {
     ...(state.dynamicSlots || []),
     ...(state.wSlots || []),
   ];
+  allSlots.forEach((label) => ensureFingerState(label));
   activeFingerState = {
     mode: state.mode,
     fixedSlots: state.fixedSlots || [],
@@ -708,12 +790,13 @@ function applyFingerState(state) {
     wSlots: activeFingerState.wSlots,
     axisConstraints: activeFingerState.axisConstraints,
   });
+  ensureFingerSubscriptions(activeFingerState.allSlots);
   syncFingerUI();
   activeFingerState.allSlots.forEach((label) => {
     refreshFingerIndicator(label);
     updateFingerDotPosition(label);
   });
-  ALL_FINGER_LABELS.forEach((label) => {
+  Array.from(knownFingerLabels).forEach((label) => {
     if (!activeFingerState.activeLabelSet.has(label)) {
       clearFingerQueryParam(label);
       const dot = fingerDots.get(label);
@@ -733,6 +816,7 @@ function applyFingerState(state) {
 }
 
 function updateFingerDotPosition(label) {
+  ensureFingerState(label);
   const dot = fingerDots.get(label);
   if (!dot || !reflexCore || !activeFingerState.activeLabelSet.has(label)) {
     if (dot) {
@@ -823,16 +907,16 @@ async function bootstrapReflexApplication() {
     if (typeof window !== 'undefined') {
       window.__reflexCore = reflexCore;
     }
-    ALL_FINGER_LABELS.forEach((label) => {
-      reflexCore.onFingerChange(label, (offset) => handleFingerValueChange(label, offset));
-    });
-
-    ALL_FINGER_LABELS.forEach((label) => {
-      const parsed = readFingerFromQuery(label);
-      if (parsed) {
-        reflexCore.setFingerValue(label, parsed.x, parsed.y);
-      }
-    });
+    // Subscribe only to the finger labels that are actually used.
+    const initialActiveLabels = initialFingerState.mode === 'invalid'
+      ? W_FINGER_ORDER
+      : [
+        ...(initialFingerState.fixedSlots || []),
+        ...(initialFingerState.dynamicSlots || []),
+        ...(initialFingerState.wSlots || []),
+      ];
+    ensureFingerSubscriptions(initialActiveLabels);
+    applyFingerValuesFromQuery(initialActiveLabels);
   }
 
   if (initialFingerState.mode !== 'invalid') {
@@ -1096,7 +1180,10 @@ async function copyShareLinkToClipboard() {
 
 function buildAnimationTracksFromQuery() {
   const tracks = new Map();
-  for (const label of ALL_FINGER_LABELS) {
+  const candidates = activeFingerState?.allSlots?.length
+    ? activeFingerState.allSlots
+    : Array.from(knownFingerLabels);
+  for (const label of candidates) {
     const interval = readAnimationIntervalFromQuery(label);
     if (interval) {
       tracks.set(label, interval);
@@ -1329,8 +1416,8 @@ function resetFingerValuesToDefaults() {
   if (!reflexCore) {
     return;
   }
-  ALL_FINGER_LABELS.forEach((label) => {
-    const defaults = DEFAULT_FINGER_OFFSETS[label];
+  Array.from(knownFingerLabels).forEach((label) => {
+    const defaults = defaultFingerOffset(label);
     reflexCore.setFingerValue(label, defaults.x, defaults.y);
   });
 }

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -1,5 +1,5 @@
 // apps/reflex4you/service-worker.js
-const CACHE_NAME = 'reflex4you-cache-v3';
+const CACHE_NAME = 'reflex4you-cache-v4';
 
 const ASSETS_TO_CACHE = [
   './',


### PR DESCRIPTION
Generalize the parser to support arbitrary `D*` and `F*` finger constants.

Previously, the parser hard-coded `D1-D3` and `F1-F3` as the only valid finger literals, preventing the use of other or non-consecutive finger labels. This change updates the parser to dynamically recognize any `D<number>` or `F<number>` (and `W1`/`W2`) as valid finger constants.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d84e155-6782-42e2-a462-9165f679e963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d84e155-6782-42e2-a462-9165f679e963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

