### PR TITLE
Browser loading issue reflex4you

### DIFF
--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -4,7 +4,7 @@ Reflex4You is an interactive complex-function explorer. Type a formula, drag the
 
 ## Quick Start
 
-1. **Open the live app:** https://mikaelmayer.github.io/apps/reflex4you  
+1. **Open the live app:** https://mikaelmayer.github.io/apps/reflex4you/  
    The viewer presents the complex function `z → z` across the rectangular domain `[-4 - 4i, 4 + 4i]`, clamped to your screen. Because every formula describes a function of `z`, the shorthand `z` means “map `z` to itself.”
 
 2. **Enter a formula.** Try:
@@ -39,7 +39,7 @@ Reflex4You is an interactive complex-function explorer. Type a formula, drag the
 
 ## Install as a PWA
 
-- On Chrome/Edge/Android, open https://mikaelmayer.github.io/apps/reflex4you, open the browser menu, and choose **Install app** (or **Add to Home screen** on iOS Safari).  
+- On Chrome/Edge/Android, open https://mikaelmayer.github.io/apps/reflex4you/, open the browser menu, and choose **Install app** (or **Add to Home screen** on iOS Safari).  
 - The shipped `manifest.json` and service worker let the viewer cache `index.html`, all ES modules, and the WebGL assets so you can explore saved formulas even when you're offline.
 - Updates ship automatically: when a new version is published, the service worker pulls fresh files after the next load and activates on the following visit.
 

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -4,6 +4,22 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#000000" />
+  <script>
+    // Some static hosts serve this page at `/apps/reflex4you` (no trailing slash)
+    // without redirecting to `/apps/reflex4you/`. In that case, relative asset
+    // URLs like `./main.js` resolve to `/apps/main.js` and the app fails to load.
+    // Normalize to a trailing-slash URL before loading any modules.
+    (function () {
+      try {
+        const { pathname, search, hash } = window.location;
+        if (pathname && !pathname.endsWith('/') && !pathname.endsWith('.html')) {
+          window.location.replace(`${pathname}/${search || ''}${hash || ''}`);
+        }
+      } catch (_) {
+        // Ignore redirect failures (non-browser contexts).
+      }
+    })();
+  </script>
   <link rel="manifest" href="./manifest.json" />
   <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png" />
   <link rel="apple-touch-icon" href="./icon-192.png" />


### PR DESCRIPTION
Fixes `apps/reflex4you` failing to load in browsers when accessed without a trailing slash.

Some static hosts serve the page at `/apps/reflex4you` (no trailing slash) without redirecting to `/apps/reflex4you/`. This causes relative asset URLs like `./main.js` to resolve incorrectly to `/apps/main.js`, leading to module 404s. PWAs often work because they open the directory form (`.../reflex4you/`). This PR adds a client-side redirect in `index.html` to normalize the URL to include a trailing slash before modules load, and updates README links.

---
<a href="https://cursor.com/background-agent?bcId=bc-c414ba34-28b4-46f7-89ac-acd2643595db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c414ba34-28b4-46f7-89ac-acd2643595db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

