### PR TITLE
Visual display bug reflex4you

### DIFF
--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -1364,6 +1364,11 @@ export class ReflexCore {
     this.fingerAxisConstraints = new Map();
     this.wGestureState = null;
     this.wGestureLatched = false;
+    // If we render before the browser has computed layout, canvas.clientWidth/Height can
+    // temporarily report 0–1px (notably on mobile/PWA). Resizing the backing store to
+    // that tiny size produces a uniform full-screen color until a later resize/re-render.
+    // Track a single scheduled retry render once layout stabilizes.
+    this._layoutRetryRaf = null;
 
     this.formulaAST = initialAST;
 
@@ -1653,14 +1658,35 @@ export class ReflexCore {
 
   resizeCanvasToDisplaySize() {
     const dpr = (typeof window !== 'undefined' ? window.devicePixelRatio : 1) || 1;
-    const displayWidth = Math.floor(this.canvas.clientWidth * dpr);
-    const displayHeight = Math.floor(this.canvas.clientHeight * dpr);
+    const cssWidth = this.canvas.clientWidth;
+    const cssHeight = this.canvas.clientHeight;
 
-    if (this.canvas.width !== displayWidth || this.canvas.height !== displayHeight) {
+    // If layout isn't ready, avoid shrinking the backing store to 0–1px. Keep the
+    // previous canvas size (or a sane fallback) and request a retry on the next frame.
+    if (!(cssWidth > 1 && cssHeight > 1)) {
+      // If a previous render already shrunk us to 0–1px, restore a reasonable default
+      // so the first visible frame isn't a single stretched pixel.
+      if (this.canvas.width <= 1 || this.canvas.height <= 1) {
+        this.canvas.width = 300;
+        this.canvas.height = 150;
+      }
+      if (this.canvas.width > 0 && this.canvas.height > 0) {
+        this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+      }
+      return { layoutReady: false, resized: false };
+    }
+
+    const displayWidth = Math.floor(cssWidth * dpr);
+    const displayHeight = Math.floor(cssHeight * dpr);
+    const resized = this.canvas.width !== displayWidth || this.canvas.height !== displayHeight;
+
+    if (resized) {
       this.canvas.width = displayWidth;
       this.canvas.height = displayHeight;
       this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
     }
+
+    return { layoutReady: true, resized };
   }
 
   updateView() {
@@ -1713,7 +1739,15 @@ export class ReflexCore {
 
   render() {
     if (!this.program) return;
-    this.resizeCanvasToDisplaySize();
+    const { layoutReady } = this.resizeCanvasToDisplaySize();
+    if (!layoutReady && typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      if (this._layoutRetryRaf == null) {
+        this._layoutRetryRaf = window.requestAnimationFrame(() => {
+          this._layoutRetryRaf = null;
+          this.render();
+        });
+      }
+    }
     this.gl.useProgram(this.program);
     this.uploadFingerUniforms();
     this.gl.uniform2f(this.uResolutionLoc, this.canvas.width, this.canvas.height);

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -406,7 +406,7 @@
       Formula view
     </button>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v3</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v6</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -30,7 +30,7 @@ const rootElement = typeof document !== 'undefined' ? document.documentElement :
 
 let fatalErrorActive = false;
 
-const APP_VERSION = 5;
+const APP_VERSION = 6;
 
 if (versionPill) {
   versionPill.textContent = `v${APP_VERSION}`;

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -1,8 +1,8 @@
 // apps/reflex4you/service-worker.js
 
 // Bump these to force clients to pick up new precache content.
-const PRECACHE_NAME = 'reflex4you-precache-v5';
-const RUNTIME_CACHE_NAME = 'reflex4you-runtime-v5';
+const PRECACHE_NAME = 'reflex4you-precache-v6';
+const RUNTIME_CACHE_NAME = 'reflex4you-runtime-v6';
 
 // Precache the app shell + all ESM modules required to boot offline.
 const PRECACHE_URLS = [


### PR DESCRIPTION
Prevent `ReflexCore` from rendering a uniform color on initial load by avoiding canvas backing store shrinkage and scheduling a retry.

On some loads (especially PWA/mobile), `canvas.clientWidth/clientHeight` can briefly report 0–1px during early layout. `ReflexCore.render()` would then resize the canvas backing store to that tiny size, causing the WebGL shader to produce a single pixel stretched fullscreen (the "uniform orange"). This fix ensures the canvas maintains a reasonable size and retries rendering once layout stabilizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fdf8fb6-d2dd-4b33-bcc1-11883ab46386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2fdf8fb6-d2dd-4b33-bcc1-11883ab46386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

