### PR TITLE
Initial image display regression

### DIFF
--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -231,6 +231,24 @@ function analyzeFingerUniformCounts(ast) {
           visit(node.branch);
         }
         return;
+      case "ComposeMultiple":
+        // Produced by the parser for the `$$` operator (repeat composition).
+        // Even though we later materialize this node before generating GLSL,
+        // we must count finger usage here so uniform arrays are sized large
+        // enough on the first render (before any formula edit).
+        visit(node.base);
+        if (node.countExpression) {
+          visit(node.countExpression);
+        }
+        return;
+      case "RepeatComposePlaceholder":
+        // Should not reach the renderer (placeholders are resolved during parse),
+        // but handle defensively so uniform sizing never under-allocates.
+        visit(node.base);
+        if (node.countExpression) {
+          visit(node.countExpression);
+        }
+        return;
       case "Sub":
       case "Mul":
       case "Op":

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -406,7 +406,7 @@
       Formula view
     </button>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v6</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v7</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -30,7 +30,7 @@ const rootElement = typeof document !== 'undefined' ? document.documentElement :
 
 let fatalErrorActive = false;
 
-const APP_VERSION = 6;
+const APP_VERSION = 7;
 
 if (versionPill) {
   versionPill.textContent = `v${APP_VERSION}`;

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -1,8 +1,8 @@
 // apps/reflex4you/service-worker.js
 
 // Bump these to force clients to pick up new precache content.
-const PRECACHE_NAME = 'reflex4you-precache-v6';
-const RUNTIME_CACHE_NAME = 'reflex4you-runtime-v6';
+const PRECACHE_NAME = 'reflex4you-precache-v7';
+const RUNTIME_CACHE_NAME = 'reflex4you-runtime-v7';
 
 // Precache the app shell + all ESM modules required to boot offline.
 const PRECACHE_URLS = [


### PR DESCRIPTION
Fixes a regression where the first displayed image was incorrect by correctly sizing uniform arrays for `ComposeMultiple` nodes.

The shader source was built from a materialized AST (expanding `$$` into repeated composition), but uniform-array sizing was computed from the non-materialized AST, which did not traverse `ComposeMultiple`. This under-allocated `u_fixedOffsets[]`/`u_dynamicOffsets[]`, causing higher-index fingers to read as 0 on first render until any edit forced a recompilation via `setFormulaAST()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-36d76d66-7e64-4871-a9af-d24982afe346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36d76d66-7e64-4871-a9af-d24982afe346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

