### PR TITLE
Pwa intermittent loading issue

### DIFF
--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -367,11 +367,9 @@
     }
 
     /* Viewer mode: hide UI chrome until first interaction. */
-    html.viewer-mode #menu-container,
     html.viewer-mode #formula-panel,
     html.viewer-mode #finger-indicator-stack,
-    html.viewer-mode #finger-overlay,
-    html.viewer-mode #error {
+    html.viewer-mode #finger-overlay {
       display: none !important;
       visibility: hidden !important;
       pointer-events: none !important;

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -367,9 +367,11 @@
     }
 
     /* Viewer mode: hide UI chrome until first interaction. */
+    html.viewer-mode #menu-container,
     html.viewer-mode #formula-panel,
     html.viewer-mode #finger-indicator-stack,
-    html.viewer-mode #finger-overlay {
+    html.viewer-mode #finger-overlay,
+    html.viewer-mode #error {
       display: none !important;
       visibility: hidden !important;
       pointer-events: none !important;


### PR DESCRIPTION
Add WebGL context loss handling and auto-reload to fix blank screen issue on mobile PWAs after backgrounding.

Mobile operating systems often reclaim GPU resources when a PWA is backgrounded, leading to WebGL context loss. The app previously did not handle this, causing the canvas to appear blank until a force-close and restart. This PR adds listeners for `webglcontextlost` and `webglcontextrestored` events, allowing the `ReflexCore` to rebuild GPU resources. Additionally, `main.js` implements a one-time auto-reload mechanism upon context loss to ensure recovery, and viewer mode CSS is adjusted to always show error messages and the menu, preventing failures from appearing as a completely blank screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6629acd-de23-48bf-8843-263c3b566fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6629acd-de23-48bf-8843-263c3b566fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

