### PR TITLE
Pwa blank screen bug

### DIFF
--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -518,7 +518,61 @@
   <textarea id="formula" spellcheck="false" aria-label="Formula"></textarea>
 </div>
 
-<script type="module" src="./main.js"></script>
+<script type="module">
+  // Boot via dynamic import so we can catch failures (instead of a blank white screen).
+  (async function () {
+    const error = document.getElementById('error');
+    const key = 'reflex4you:bootReloadedOnce';
+
+    function showBootError(msg) {
+      if (!error) return;
+      error.setAttribute('data-error-severity', 'fatal');
+      error.textContent = msg;
+      error.style.display = 'block';
+    }
+
+    function reloadOnce(reason) {
+      try {
+        if (sessionStorage.getItem(key)) return false;
+        sessionStorage.setItem(key, String(Date.now()));
+      } catch (_) {
+        // If sessionStorage is unavailable, still try once (best effort).
+      }
+      try {
+        const url = new URL(location.href);
+        url.searchParams.set('bootfix', String(Date.now()));
+        url.hash = location.hash || '';
+        location.replace(url.toString());
+        return true;
+      } catch (_) {
+        try { location.reload(); } catch (_) {}
+        return true;
+      }
+    }
+
+    // If we don’t finish boot quickly, show a message and try a one-time reload.
+    const bootTimer = setTimeout(() => {
+      showBootError('Reflex4You did not finish loading.\nReloading to recover…');
+      reloadOnce('timeout');
+    }, 3500);
+
+    try {
+      await import('./main.js');
+      clearTimeout(bootTimer);
+    } catch (e) {
+      clearTimeout(bootTimer);
+      const details = e && (e.stack || e.message) ? String(e.stack || e.message) : String(e);
+      showBootError(`Reflex4You failed to start.\n\n${details}\n\nTap to reload.`);
+      // Make the “tap -> white screen” become “tap -> recover”.
+      document.addEventListener(
+        'pointerdown',
+        () => reloadOnce('tap'),
+        { once: true, capture: true },
+      );
+      reloadOnce('import-failed');
+    }
+  })();
+</script>
 
 </body>
 </html>

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -376,6 +376,63 @@
       visibility: hidden !important;
       pointer-events: none !important;
     }
+
+    /* Boot/recovery overlay should always be visible, even in viewer mode. */
+    #boot-overlay {
+      position: fixed;
+      inset: 0;
+      display: none;
+      z-index: 9999;
+      background: rgba(0, 0, 0, 0.92);
+      color: rgba(255, 255, 255, 0.92);
+      padding: calc(var(--safe-area-top) + 18px) 16px calc(var(--safe-area-bottom) + 18px);
+      box-sizing: border-box;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    }
+
+    #boot-overlay .boot-card {
+      max-width: 720px;
+      margin: 0 auto;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.06);
+      padding: 14px 14px;
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.5);
+    }
+
+    #boot-overlay .boot-title {
+      font-weight: 650;
+      letter-spacing: 0.01em;
+      margin-bottom: 8px;
+    }
+
+    #boot-overlay .boot-msg {
+      white-space: pre-wrap;
+      color: rgba(255, 255, 255, 0.82);
+      font-size: 13px;
+      line-height: 1.4;
+      margin: 0 0 12px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    }
+
+    #boot-overlay .boot-actions {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    #boot-overlay button {
+      appearance: none;
+      border: 1px solid rgba(255, 255, 255, 0.22);
+      background: rgba(255, 255, 255, 0.08);
+      color: rgba(255, 255, 255, 0.92);
+      border-radius: 10px;
+      padding: 10px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      touch-action: manipulation;
+    }
   </style>
 </head>
 <body>
@@ -514,6 +571,16 @@
 
 <div id="error"></div>
 
+<div id="boot-overlay" role="dialog" aria-modal="true" aria-label="Reflex4You recovery">
+  <div class="boot-card">
+    <div class="boot-title">Reflex4You didn’t load</div>
+    <div id="boot-overlay-message" class="boot-msg"></div>
+    <div class="boot-actions">
+      <button id="boot-overlay-reload" type="button">Reload</button>
+    </div>
+  </div>
+</div>
+
 <div id="formula-panel">
   <textarea id="formula" spellcheck="false" aria-label="Formula"></textarea>
 </div>
@@ -522,9 +589,18 @@
   // Boot via dynamic import so we can catch failures (instead of a blank white screen).
   (async function () {
     const error = document.getElementById('error');
+    const bootOverlay = document.getElementById('boot-overlay');
+    const bootOverlayMessage = document.getElementById('boot-overlay-message');
+    const bootOverlayReload = document.getElementById('boot-overlay-reload');
     const key = 'reflex4you:bootReloadedOnce';
 
     function showBootError(msg) {
+      try {
+        if (bootOverlay) bootOverlay.style.display = 'block';
+        if (bootOverlayMessage) bootOverlayMessage.textContent = String(msg || '');
+      } catch (_) {
+        // ignore
+      }
       if (!error) return;
       error.setAttribute('data-error-severity', 'fatal');
       error.textContent = msg;
@@ -557,6 +633,25 @@
     }, 3500);
 
     try {
+      // If a SW update is mid-flight, "controllerchange" can fix weird cold-start states.
+      if ('serviceWorker' in navigator && navigator.serviceWorker) {
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          reloadOnce('sw-controllerchange');
+        });
+        try {
+          const reg = await navigator.serviceWorker.getRegistration();
+          if (reg?.waiting) {
+            reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+          }
+        } catch (_) {
+          // ignore
+        }
+      }
+
+      if (bootOverlayReload) {
+        bootOverlayReload.addEventListener('click', () => reloadOnce('button'));
+      }
+
       await import('./main.js');
       clearTimeout(bootTimer);
     } catch (e) {

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -1999,7 +1999,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=11.8';
+  const SW_URL = './service-worker.js?sw=11.9';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -364,7 +364,7 @@ function scheduleCommitHistorySnapshot() {
 }
 
 function applyHistorySnapshot(snapshot) {
-  if (!snapshot || !reflexCore) {
+  if (!snapshot) {
     return;
   }
   historyApplying = true;
@@ -384,7 +384,7 @@ function applyHistorySnapshot(snapshot) {
         const v = fingers[label];
         if (!v) continue;
         latestOffsets[label] = { x: v.x, y: v.y };
-        reflexCore.setFingerValue(label, v.x, v.y, { triggerRender: false });
+        reflexCore?.setFingerValue(label, v.x, v.y, { triggerRender: false });
       }
     } finally {
       suppressFingerQueryUpdates = false;
@@ -403,7 +403,7 @@ function applyHistorySnapshot(snapshot) {
       console.warn('Failed to persist formula parameter.', error),
     );
 
-    reflexCore.render();
+    reflexCore?.render();
   } finally {
     historyApplying = false;
     updateUndoRedoButtons();

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -44,9 +44,8 @@ const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
 // Empirically, some mobile PWAs end up in a broken/blank state after being backgrounded
 // long enough for the OS to suspend/kill GPU resources. Reloading on resume is the most
-// reliable recovery. The user reports the issue begins around 25s; use a slightly lower
-// threshold to be safe.
-const RESUME_RELOAD_THRESHOLD_MS = 22000;
+// reliable recovery. The user reports the issue begins around 20s.
+const RESUME_RELOAD_THRESHOLD_MS = 20000;
 
 if (versionPill) {
   versionPill.textContent = `v${APP_VERSION}`;

--- a/apps/reflex4you/manifest.json
+++ b/apps/reflex4you/manifest.json
@@ -5,7 +5,7 @@
   "lang": "en",
   "dir": "ltr",
   "id": "/apps/reflex4you/",
-  "start_url": "./",
+  "start_url": "./index.html",
   "scope": "./",
   "display": "standalone",
   "display_override": ["fullscreen", "standalone", "minimal-ui"],

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '11.8';
+const CACHE_MINOR = '11.9';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Update PWA `start_url` to prevent blank screens on reopen.

The PWA was occasionally launching outside the Service Worker's scope, leading to a blank UI on reopen, especially after being backgrounded. Changing `start_url` to `./index.html` ensures it always launches within the SW's control. Additionally, `applyHistorySnapshot` was made more robust to allow undo/redo functionality even if `reflexCore` is not initialized, improving behavior in headless or WebGL-limited environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba7ec55d-60df-4955-a0e7-d05df4ce49b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ba7ec55d-60df-4955-a0e7-d05df4ce49b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

