### PR TITLE
Formula identifier metadata rendering

### DIFF
--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -1093,6 +1093,7 @@ function substitutePlaceholder(node, placeholder, replacement) {
     case 'Acos':
     case 'Abs':
     case 'Abs2':
+    case 'Floor':
     case 'Conjugate':
       return { ...node, value: substitutePlaceholder(node.value, placeholder, replacement) };
     case 'Ln': {
@@ -1194,6 +1195,7 @@ function cloneAst(node) {
     case 'Acos':
     case 'Abs':
     case 'Abs2':
+    case 'Floor':
     case 'Conjugate':
       return { ...node, value: cloneAst(node.value) };
     case 'Ln':
@@ -1292,6 +1294,7 @@ function substituteIdentifierWithClone(node, targetName, replacement) {
     case 'Acos':
     case 'Abs':
     case 'Abs2':
+    case 'Floor':
     case 'Conjugate':
       return { ...node, value: substituteIdentifierWithClone(node.value, targetName, replacement) };
     case 'Ln': {
@@ -1389,6 +1392,7 @@ function findFirstPlaceholderNode(ast) {
       case 'Ln':
       case 'Abs':
       case 'Abs2':
+      case 'Floor':
       case 'Conjugate':
         stack.push(node.value);
         if (node.kind === 'Ln' && node.branch) {
@@ -1464,6 +1468,7 @@ function findFirstLetBinding(ast) {
       case 'Ln':
       case 'Abs':
       case 'Abs2':
+      case 'Floor':
       case 'Conjugate':
         stack.push(node.value);
         if (node.kind === 'Ln' && node.branch) {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -5,6 +5,7 @@ import {
   parseFormulaToAST,
 } from './arithmetic-parser.mjs';
 import { visitAst } from './ast-utils.mjs';
+import { formulaAstToLatex } from './formula-renderer.mjs';
 
 test('parses additive and multiplicative precedence', () => {
   const result = parseFormulaInput('1 + 2 * 3');
@@ -591,4 +592,18 @@ test('standalone iteration variables are rejected', () => {
   const result = parseFormulaInput('v + 1');
   assert.equal(result.ok, false);
   assert.match(result.message, /comp/i);
+});
+
+test('underscore-marked identifiers record highlight metadata and render as Huge letters (LEON)', () => {
+  const source = '_ln(_exp(_o(si_n, z*z)-3)-1)';
+  const result = parseFormulaInput(source);
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /\{\\Huge L\}/);
+  assert.match(latex, /\{\\Huge E\}/);
+  assert.match(latex, /\{\\Huge O\}/);
+  assert.match(latex, /\{\\Huge N\}/);
+  assert.ok(latex.indexOf('{\\Huge L}') < latex.indexOf('{\\Huge E}'));
+  assert.ok(latex.indexOf('{\\Huge E}') < latex.indexOf('{\\Huge O}'));
+  assert.ok(latex.indexOf('{\\Huge O}') < latex.indexOf('{\\Huge N}'));
 });

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -607,3 +607,11 @@ test('underscore-marked identifiers record highlight metadata and render as Huge
   assert.ok(latex.indexOf('{\\Huge E}') < latex.indexOf('{\\Huge O}'));
   assert.ok(latex.indexOf('{\\Huge O}') < latex.indexOf('{\\Huge N}'));
 });
+
+test('comp(...) can clone floor(...) nodes (cloneAst supports Floor)', () => {
+  assert.doesNotThrow(() => {
+    const result = parseFormulaInput('comp(v+1, v, floor(z), 0)');
+    assert.equal(result.ok, true);
+    assert.equal(result.value.kind, 'Floor');
+  });
+});

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -1,6 +1,6 @@
 import { parseFormulaInput } from './arithmetic-parser.mjs';
 import { formatCaretIndicator } from './parse-error-format.mjs';
-import { renderFormulaToContainer, FORMULA_RENDERER_BUILD_ID } from './formula-renderer.mjs';
+import { renderFormulaToCanvas, FORMULA_RENDERER_BUILD_ID } from './formula-renderer.mjs';
 import {
   verifyCompressionSupport,
   readFormulaFromQuery,
@@ -53,13 +53,6 @@ function showError(message) {
   }
 }
 
-function setLatexPreview(latex) {
-  const latexEl = $('formula-latex');
-  if (latexEl) {
-    latexEl.textContent = latex || '';
-  }
-}
-
 function showStaleWarning(message) {
   const el = $('stale-warning');
   if (!el) return;
@@ -75,11 +68,13 @@ function showStaleWarning(message) {
 function clearRender() {
   const renderEl = $('formula-render');
   if (renderEl) {
-    renderEl.textContent = '';
+    const ctx = renderEl.getContext?.('2d');
+    if (ctx) {
+      ctx.clearRect(0, 0, renderEl.width || 0, renderEl.height || 0);
+    }
     renderEl.removeAttribute('data-latex');
     renderEl.removeAttribute('data-renderer');
   }
-  setLatexPreview('');
   showStaleWarning(null);
 }
 
@@ -129,9 +124,8 @@ async function renderFromSource(source, { updateUrl = false } = {}) {
 
   showError(null);
   const renderEl = $('formula-render');
-  await renderFormulaToContainer(parsed.value, renderEl);
+  await renderFormulaToCanvas(parsed.value, renderEl);
   const latex = renderEl?.dataset?.latex || '';
-  setLatexPreview(latex);
   showStaleWarning(buildStaleDiagnostic({ latex, renderEl }));
   return { ok: true };
 }

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -36,9 +36,33 @@ if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
 }
 
 const DEFAULT_FORMULA_TEXT = 'z';
+const DEFAULT_CANVAS_BG_HEX = 'ffffff80';
 
 function $(id) {
   return document.getElementById(id);
+}
+
+function normalizeHex8(value) {
+  const raw = String(value || '').trim().replace(/^#/, '');
+  if (raw.length === 6 && /^[0-9a-fA-F]{6}$/.test(raw)) {
+    return `${raw}ff`.toLowerCase();
+  }
+  if (raw.length === 8 && /^[0-9a-fA-F]{8}$/.test(raw)) {
+    return raw.toLowerCase();
+  }
+  return null;
+}
+
+function readCanvasBackgroundHex() {
+  const el = $('bghex');
+  const parsed = normalizeHex8(el?.value);
+  return parsed || DEFAULT_CANVAS_BG_HEX;
+}
+
+function setDownloadEnabled(enabled) {
+  const btn = $('download-png');
+  if (!btn) return;
+  btn.disabled = !enabled;
 }
 
 function showError(message) {
@@ -75,6 +99,7 @@ function clearRender() {
     renderEl.removeAttribute('data-latex');
     renderEl.removeAttribute('data-renderer');
   }
+  setDownloadEnabled(false);
   showStaleWarning(null);
 }
 
@@ -124,9 +149,12 @@ async function renderFromSource(source, { updateUrl = false } = {}) {
 
   showError(null);
   const renderEl = $('formula-render');
-  await renderFormulaToCanvas(parsed.value, renderEl);
+  await renderFormulaToCanvas(parsed.value, renderEl, {
+    backgroundHex: readCanvasBackgroundHex(),
+  });
   const latex = renderEl?.dataset?.latex || '';
   showStaleWarning(buildStaleDiagnostic({ latex, renderEl }));
+  setDownloadEnabled(true);
   return { ok: true };
 }
 
@@ -144,6 +172,47 @@ async function bootstrap() {
   const inputEl = $('formula-input');
   if (inputEl) {
     inputEl.value = source;
+  }
+
+  // Background controls.
+  const bgEl = $('bghex');
+  if (bgEl && !normalizeHex8(bgEl.value)) {
+    bgEl.value = DEFAULT_CANVAS_BG_HEX;
+  }
+  if (bgEl) {
+    bgEl.addEventListener('input', () => {
+      // Re-render without touching the URL; just affects the raster background.
+      const current = inputEl ? inputEl.value : source;
+      renderFromSource(current, { updateUrl: false }).catch(() => {});
+    });
+  }
+  document.querySelectorAll?.('button[data-bghex]')?.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const next = normalizeHex8(btn.getAttribute('data-bghex')) || DEFAULT_CANVAS_BG_HEX;
+      if (bgEl) bgEl.value = next;
+      const current = inputEl ? inputEl.value : source;
+      renderFromSource(current, { updateUrl: false }).catch(() => {});
+    });
+  });
+
+  // Download.
+  const downloadBtn = $('download-png');
+  if (downloadBtn) {
+    downloadBtn.addEventListener('click', () => {
+      const canvas = $('formula-render');
+      if (!canvas || typeof canvas.toDataURL !== 'function') return;
+      try {
+        const href = canvas.toDataURL('image/png');
+        const a = document.createElement('a');
+        a.href = href;
+        a.download = 'formula.png';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+      } catch (e) {
+        console.warn('Failed to download canvas PNG.', e);
+      }
+    });
   }
 
   await renderFromSource(source, { updateUrl: false });

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -2,7 +2,7 @@
 // Produces a LaTeX string from the Reflex4You AST and renders it via MathJax.tex2svg.
 
 // Bump this when changing renderer logic so users can verify cached assets.
-export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2025-12-15.1';
+export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2025-12-16.1';
 
 const DEFAULT_MATHJAX_LOAD_TIMEOUT_MS = 9000;
 
@@ -48,6 +48,53 @@ function formatNumber(value) {
 
 function escapeLatexIdentifier(name) {
   return String(name || '?').replace(/_/g, '\\_');
+}
+
+function identifierHighlights(node) {
+  const highlights = node && typeof node === 'object' ? node.__identifierMeta?.highlights : null;
+  return Array.isArray(highlights) ? highlights : [];
+}
+
+function escapeLatexTextChar(ch) {
+  if (ch === '_') return '\\_';
+  if (ch === '\\') return '\\textbackslash{}';
+  if (ch === '{') return '\\{';
+  if (ch === '}') return '\\}';
+  return ch;
+}
+
+function renderTextWithHighlights(text, highlights) {
+  const raw = String(text || '?');
+  const list = Array.isArray(highlights) ? highlights : [];
+  const byIndex = new Map();
+  list.forEach((h) => {
+    if (!h || typeof h.index !== 'number') return;
+    byIndex.set(h.index, h.letter);
+  });
+
+  let out = '';
+  for (let i = 0; i < raw.length; i += 1) {
+    const letter = byIndex.get(i);
+    if (typeof letter === 'string' && letter.length) {
+      out += `{\\Huge ${escapeLatexTextChar(letter[0].toUpperCase())}}`;
+      continue;
+    }
+    out += escapeLatexTextChar(raw[i]);
+  }
+  return out;
+}
+
+function latexIdentifierWithMetadata(name, metaHighlights) {
+  const highlights = Array.isArray(metaHighlights) ? metaHighlights : [];
+  if (!highlights.length) {
+    return escapeLatexIdentifier(name);
+  }
+  return renderTextWithHighlights(name, highlights);
+}
+
+function operatorNameWithMetadata(name, metaHighlights) {
+  const inner = latexIdentifierWithMetadata(name, metaHighlights);
+  return `\\operatorname{${inner}}`;
 }
 
 function isLatexAlreadyWrappedInParens(latex) {
@@ -155,14 +202,14 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
     case 'Const':
       return constToLatex(node);
     case 'Var':
-      return escapeLatexIdentifier(node.name || 'z');
+      return latexIdentifierWithMetadata(node.name || 'z', identifierHighlights(node));
     case 'VarX':
-      return 'x';
+      return latexIdentifierWithMetadata('x', identifierHighlights(node));
     case 'VarY':
-      return 'y';
+      return latexIdentifierWithMetadata('y', identifierHighlights(node));
     case 'Identifier':
     case 'SetRef':
-      return escapeLatexIdentifier(node.name || '?');
+      return latexIdentifierWithMetadata(node.name || '?', identifierHighlights(node));
     case 'FingerOffset':
       return fingerSlotToLatex(node.slot);
 
@@ -185,26 +232,27 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
     }
 
     case 'Exp':
-      return `\\exp\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
+      return `${identifierHighlights(node).length ? operatorNameWithMetadata('exp', identifierHighlights(node)) : '\\exp'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Sin':
-      return `\\sin\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
+      return `${identifierHighlights(node).length ? operatorNameWithMetadata('sin', identifierHighlights(node)) : '\\sin'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Cos':
-      return `\\cos\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
+      return `${identifierHighlights(node).length ? operatorNameWithMetadata('cos', identifierHighlights(node)) : '\\cos'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Tan':
-      return `\\tan\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
+      return `${identifierHighlights(node).length ? operatorNameWithMetadata('tan', identifierHighlights(node)) : '\\tan'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Atan':
-      return `\\arctan\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
+      return `${identifierHighlights(node).length ? operatorNameWithMetadata('atan', identifierHighlights(node)) : '\\arctan'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Asin':
-      return `\\arcsin\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
+      return `${identifierHighlights(node).length ? operatorNameWithMetadata('asin', identifierHighlights(node)) : '\\arcsin'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Acos':
-      return `\\arccos\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
+      return `${identifierHighlights(node).length ? operatorNameWithMetadata('acos', identifierHighlights(node)) : '\\arccos'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Ln': {
       const value = nodeToLatex(node.value, 0, options);
+      const op = identifierHighlights(node).length ? operatorNameWithMetadata('ln', identifierHighlights(node)) : '\\ln';
       if (node.branch) {
         const branch = nodeToLatex(node.branch, 0, options);
-        return `\\ln_{${branch}}\\left(${value}\\right)`;
+        return `${op}_{${branch}}\\left(${value}\\right)`;
       }
-      return `\\ln\\left(${value}\\right)`;
+      return `${op}\\left(${value}\\right)`;
     }
     case 'Abs':
       return `\\left|${nodeToLatex(node.value, 0, options)}\\right|`;
@@ -273,7 +321,12 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
           return `${leftWrapped} \\lor ${rightWrapped}`;
         }
         case 'Compose': {
-          return `${leftWrapped} \\circ ${rightWrapped}`;
+          const meta = identifierHighlights(node);
+          const injected =
+            meta.length
+              ? `{\\Huge ${escapeLatexTextChar(String(meta[0]?.letter || 'o')[0].toUpperCase())}}\\,`
+              : '';
+          return `${injected}${leftWrapped} \\circ ${rightWrapped}`;
         }
         default:
           return '?';
@@ -311,12 +364,110 @@ async function waitForMathJaxStartup(win, { timeoutMs = DEFAULT_MATHJAX_LOAD_TIM
   return Boolean(win?.MathJax?.tex2svg);
 }
 
+export function formulaAstToLatex(ast, options = {}) {
+  return nodeToLatex(ast, 0, options);
+}
+
+function resizeCanvasToDisplaySize(canvas) {
+  const dpr = (typeof window !== 'undefined' ? window.devicePixelRatio : 1) || 1;
+  const cssWidth = canvas?.clientWidth || canvas?.width || 0;
+  const cssHeight = canvas?.clientHeight || canvas?.height || 0;
+  const w = Math.max(1, Math.floor(cssWidth * dpr));
+  const h = Math.max(1, Math.floor(cssHeight * dpr));
+  if (canvas.width !== w) canvas.width = w;
+  if (canvas.height !== h) canvas.height = h;
+  return { width: w, height: h, dpr };
+}
+
+function getSvgViewBoxSize(svgEl) {
+  const viewBox = svgEl?.getAttribute?.('viewBox') || '';
+  const parts = viewBox.split(/[ ,]+/).map((x) => Number(x)).filter((x) => Number.isFinite(x));
+  if (parts.length === 4 && parts[2] > 0 && parts[3] > 0) {
+    return { width: parts[2], height: parts[3] };
+  }
+  const wAttr = svgEl?.getAttribute?.('width') || '';
+  const hAttr = svgEl?.getAttribute?.('height') || '';
+  const w = Number(String(wAttr).replace(/[^0-9.]/g, ''));
+  const h = Number(String(hAttr).replace(/[^0-9.]/g, ''));
+  if (Number.isFinite(w) && Number.isFinite(h) && w > 0 && h > 0) {
+    return { width: w, height: h };
+  }
+  return null;
+}
+
+export async function renderLatexToCanvas(latex, canvas, options = {}) {
+  if (!canvas) return;
+  const ctx = canvas.getContext?.('2d');
+  if (!ctx) return;
+
+  const win = typeof window !== 'undefined' ? window : null;
+  const ready = await waitForMathJaxStartup(win);
+  if (!ready || typeof win.MathJax?.tex2svg !== 'function') {
+    const { width, height } = resizeCanvasToDisplaySize(canvas);
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = '#1e3a8a';
+    ctx.fillRect(0, 0, width, height);
+    ctx.fillStyle = 'rgba(255,255,255,0.85)';
+    ctx.font = '16px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
+    ctx.fillText(String(latex || ''), 16, 28);
+    return;
+  }
+
+  const mjxNode = win.MathJax.tex2svg(String(latex || ''), { display: true });
+  const svg = mjxNode?.querySelector?.('svg');
+  if (!svg) {
+    return;
+  }
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  // Ensure a deterministic color when rasterizing the SVG.
+  svg.setAttribute('style', `${svg.getAttribute('style') || ''};color:#000;`);
+
+  const serializer = new XMLSerializer();
+  const svgText = serializer.serializeToString(svg);
+  const blob = new Blob([svgText], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const img = new Image();
+    img.decoding = 'async';
+    const loaded = new Promise((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = (e) => reject(e);
+    });
+    img.src = url;
+    await loaded;
+
+    const { width, height } = resizeCanvasToDisplaySize(canvas);
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = '#1e3a8a';
+    ctx.fillRect(0, 0, width, height);
+
+    const size = getSvgViewBoxSize(svg) || { width: img.width || 1, height: img.height || 1 };
+    const pad = 24;
+    const maxW = Math.max(1, width - pad * 2);
+    const maxH = Math.max(1, height - pad * 2);
+    const scale = Math.min(maxW / size.width, maxH / size.height);
+    const drawW = size.width * scale;
+    const drawH = size.height * scale;
+    const dx = (width - drawW) / 2;
+    const dy = (height - drawH) / 2;
+
+    // Slight translucent white behind the formula.
+    ctx.fillStyle = 'rgba(255,255,255,0.18)';
+    ctx.fillRect(Math.max(0, dx - 10), Math.max(0, dy - 10), Math.min(width, drawW + 20), Math.min(height, drawH + 20));
+
+    ctx.drawImage(img, dx, dy, drawW, drawH);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
 export async function renderFormulaToContainer(ast, container, options = {}) {
   if (!container) {
     return;
   }
 
-  const latex = nodeToLatex(ast, 0, options);
+  const latex = formulaAstToLatex(ast, options);
   container.dataset.latex = latex;
   container.dataset.renderer = 'unknown';
   container.dataset.rendererBuildId = FORMULA_RENDERER_BUILD_ID;
@@ -345,5 +496,14 @@ export async function renderFormulaToContainer(ast, container, options = {}) {
   }
   container.appendChild(mjxNode);
   container.dataset.renderer = 'mathjax';
+}
+
+export async function renderFormulaToCanvas(ast, canvas, options = {}) {
+  if (!canvas) return;
+  const latex = formulaAstToLatex(ast, options);
+  canvas.dataset.latex = latex;
+  canvas.dataset.renderer = 'canvas';
+  canvas.dataset.rendererBuildId = FORMULA_RENDERER_BUILD_ID;
+  await renderLatexToCanvas(latex, canvas, options);
 }
 

--- a/apps/reflex4you/formula.html
+++ b/apps/reflex4you/formula.html
@@ -235,6 +235,56 @@
       outline: none;
     }
 
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+      margin: 10px 0 12px;
+    }
+    .controls__field {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .controls__label {
+      font-size: 12px;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+    }
+    .controls__input {
+      width: 120px;
+      padding: 8px 10px;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(0, 0, 0, 0.22);
+      color: rgba(255, 255, 255, 0.92);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size: 12px;
+      outline: none;
+    }
+    .controls__input:focus-visible {
+      border-color: rgba(125, 211, 252, 0.55);
+      box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.12);
+    }
+    .preset {
+      padding: 6px 9px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      background: rgba(0, 0, 0, 0.18);
+      color: rgba(255, 255, 255, 0.86);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size: 11px;
+      cursor: pointer;
+      line-height: 1;
+    }
+    .preset:hover,
+    .preset:focus-visible {
+      border-color: rgba(255, 255, 255, 0.32);
+      outline: none;
+    }
+
     .build-info {
       margin: 0 0 12px;
       padding: 10px 12px;
@@ -276,6 +326,17 @@
         <pre id="formula-error" class="error" aria-live="polite"></pre>
         <p class="block-label">Preview (Canvas)</p>
         <p class="block-help">This is rasterized from MathJax’s SVG output and drawn onto a canvas.</p>
+        <div class="controls">
+          <div class="controls__field">
+            <span class="controls__label">Canvas background (RRGGBBAA)</span>
+            <input id="bghex" class="controls__input" type="text" value="ffffff80" spellcheck="false" inputmode="text" aria-label="Canvas background in RRGGBBAA hex" />
+            <button class="preset" type="button" data-bghex="ffffff80">white50</button>
+            <button class="preset" type="button" data-bghex="1e3a8aff">blue</button>
+            <button class="preset" type="button" data-bghex="000000ff">black</button>
+            <button class="preset" type="button" data-bghex="00000000">transparent</button>
+          </div>
+          <button id="download-png" class="btn" type="button" disabled>Download PNG</button>
+        </div>
         <div class="formula" aria-label="Rendered formula">
           <canvas id="formula-render" class="formula-canvas"></canvas>
         </div>

--- a/apps/reflex4you/formula.html
+++ b/apps/reflex4you/formula.html
@@ -167,12 +167,18 @@
     }
 
     .formula {
-      padding: 18px 14px;
+      padding: 0;
       border-radius: 14px;
       border: 1px solid rgba(255, 255, 255, 0.12);
       background: rgba(0, 0, 0, 0.28);
-      overflow-x: auto;
+      overflow: hidden;
       color: rgba(255, 255, 255, 0.92);
+    }
+
+    .formula-canvas {
+      display: block;
+      width: 100%;
+      height: 220px;
     }
 
     .block-label {
@@ -242,38 +248,7 @@
       word-break: break-word;
     }
 
-    /* Ensure MathJax SVG scales with the card width */
-    #formula-render mjx-container {
-      display: block;
-    }
-    #formula-render svg {
-      max-width: 100%;
-      height: auto;
-    }
-
-    .source {
-      margin-top: 14px;
-      border-top: 1px solid rgba(255, 255, 255, 0.08);
-      padding-top: 12px;
-    }
-    .source__label {
-      font-size: 12px;
-      color: var(--muted);
-      margin: 0 0 6px;
-      letter-spacing: 0.02em;
-    }
-    .source__value {
-      margin: 0;
-      padding: 10px 12px;
-      border-radius: 10px;
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      background: rgba(0, 0, 0, 0.22);
-      color: rgba(255, 255, 255, 0.86);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-      font-size: 12px;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
+    /* Canvas is responsive; JS sizes the backing store to match. */
   </style>
 </head>
 <body>
@@ -299,13 +274,10 @@
           <textarea id="formula-input" class="editor__input" spellcheck="false" aria-label="Formula source"></textarea>
         </div>
         <pre id="formula-error" class="error" aria-live="polite"></pre>
-        <p class="block-label">Preview (MathJax SVG)</p>
-        <p class="block-help">This is the rendered image generated from the LaTeX below.</p>
-        <div id="formula-render" class="formula" aria-label="Rendered formula"></div>
-
-        <div class="source">
-          <p class="source__label">Generated LaTeX (input to MathJax)</p>
-          <pre id="formula-latex" class="source__value"></pre>
+        <p class="block-label">Preview (Canvas)</p>
+        <p class="block-help">This is rasterized from MathJax’s SVG output and drawn onto a canvas.</p>
+        <div class="formula" aria-label="Rendered formula">
+          <canvas id="formula-render" class="formula-canvas"></canvas>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Enables highlighting specific letters in formula identifiers for `{\Huge ...}` LaTeX rendering and updates the formula display to use a reusable canvas.

This change allows users to mark letters in identifiers (e.g., `_ln`, `si_n`) which are then rendered with `{\Huge ...}` in the generated LaTeX, fulfilling the requirement to make certain letters stand out. Additionally, the formula output is now drawn onto a canvas with a custom blue background and translucent white formula area, replacing the previous direct SVG and LaTeX text display, and providing a generic rendering utility for future use.

---
<a href="https://cursor.com/background-agent?bcId=bc-62a1e61d-1182-476f-9b23-e7cd1c0cb28f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62a1e61d-1182-476f-9b23-e7cd1c0cb28f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

