### PR TITLE
Formula composition desugaring issue

### DIFF
--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -295,8 +295,110 @@ function analyzeFingerUniformCounts(ast) {
   };
 }
 
+function cloneAstForMaterialization(node, bindingClones = new Map()) {
+  if (!node || typeof node !== "object") {
+    return node;
+  }
+
+  // Preserve any metadata fields (e.g. spans, syntax labels, function literals)
+  // by copying the object, then recursively cloning children by kind.
+  switch (node.kind) {
+    case "Pow":
+      return { ...node, base: cloneAstForMaterialization(node.base, bindingClones) };
+    case "Exp":
+    case "Sin":
+    case "Cos":
+    case "Tan":
+    case "Atan":
+    case "Asin":
+    case "Acos":
+    case "Abs":
+    case "Abs2":
+    case "Floor":
+    case "Conjugate":
+      return { ...node, value: cloneAstForMaterialization(node.value, bindingClones) };
+    case "Ln":
+      return {
+        ...node,
+        value: cloneAstForMaterialization(node.value, bindingClones),
+        branch: node.branch ? cloneAstForMaterialization(node.branch, bindingClones) : null,
+      };
+    case "Sub":
+    case "Mul":
+    case "Op":
+    case "Add":
+    case "Div":
+    case "LessThan":
+    case "GreaterThan":
+    case "LessThanOrEqual":
+    case "GreaterThanOrEqual":
+    case "Equal":
+    case "LogicalAnd":
+    case "LogicalOr":
+      return {
+        ...node,
+        left: cloneAstForMaterialization(node.left, bindingClones),
+        right: cloneAstForMaterialization(node.right, bindingClones),
+      };
+    case "If":
+      return {
+        ...node,
+        condition: cloneAstForMaterialization(node.condition, bindingClones),
+        thenBranch: cloneAstForMaterialization(node.thenBranch, bindingClones),
+        elseBranch: cloneAstForMaterialization(node.elseBranch, bindingClones),
+      };
+    case "Compose":
+      return {
+        ...node,
+        f: cloneAstForMaterialization(node.f, bindingClones),
+        g: cloneAstForMaterialization(node.g, bindingClones),
+      };
+    case "ComposeMultiple":
+      return {
+        ...node,
+        base: cloneAstForMaterialization(node.base, bindingClones),
+        countExpression: node.countExpression ? cloneAstForMaterialization(node.countExpression, bindingClones) : null,
+      };
+    case "RepeatComposePlaceholder":
+      return {
+        ...node,
+        base: cloneAstForMaterialization(node.base, bindingClones),
+        countExpression: node.countExpression ? cloneAstForMaterialization(node.countExpression, bindingClones) : null,
+      };
+    case "SetBinding":
+      // Set bindings are referenced by identity from SetRef nodes. Preserve the
+      // binding graph by cloning the binding node first, registering it, then
+      // cloning its children.
+      if (bindingClones.has(node)) {
+        return bindingClones.get(node);
+      }
+      {
+        const cloned = { ...node, value: null, body: null };
+        bindingClones.set(node, cloned);
+        cloned.value = cloneAstForMaterialization(node.value, bindingClones);
+        cloned.body = cloneAstForMaterialization(node.body, bindingClones);
+        return cloned;
+      }
+    case "SetRef": {
+      const binding = node.binding && bindingClones.has(node.binding) ? bindingClones.get(node.binding) : node.binding;
+      return { ...node, binding };
+    }
+    case "Var":
+    case "VarX":
+    case "VarY":
+    case "FingerOffset":
+    case "Const":
+    default:
+      return { ...node };
+  }
+}
+
 function materializeComposeMultiples(ast) {
-  let root = ast;
+  // IMPORTANT: materialization is for shader code generation only. It must not
+  // mutate the original AST, because the UI formula display should keep
+  // `ComposeMultiple` compact (e.g. render as "^{\\circ 40}" instead of 40 chained
+  // compositions).
+  let root = cloneAstForMaterialization(ast);
   function visit(node, parent, key) {
     if (!node || typeof node !== "object") {
       return;
@@ -1576,7 +1678,9 @@ export class ReflexCore {
   }
 
   setFormulaAST(ast) {
-    this.formulaAST = materializeComposeMultiples(ast);
+    // Keep the original AST for display/export. Shader generation will
+    // materialize `ComposeMultiple` on-demand without mutating this AST.
+    this.formulaAST = ast;
     this.rebuildProgram();
     this.render();
   }

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=13.0';
+  const SW_URL = './service-worker.js?sw=14.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -570,7 +570,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v13</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v14</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -39,7 +39,7 @@ const rootElement = typeof document !== 'undefined' ? document.documentElement :
 
 let fatalErrorActive = false;
 
-const APP_VERSION = 13;
+const APP_VERSION = 14;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -2170,7 +2170,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=13.0';
+  const SW_URL = './service-worker.js?sw=14.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '13.0';
+const CACHE_MINOR = '14.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Stop `$$` operator from unrolling repeated composition in formula display by cloning the AST before shader materialization.

Previously, the AST was mutated to unroll `ComposeMultiple` nodes (e.g., `f $$ 40`) into long `Compose` chains for WebGL shader generation. This mutated AST was then reused for formula display, causing the UI to render 40 explicit compositions instead of a compact `f^{\circ 40}`. This PR fixes the issue by cloning the AST before materializing `ComposeMultiple` nodes for shader generation, ensuring the original AST remains compact for display. It also includes a fix to preserve `set` binding identity during this cloning process, preventing `set_binding_slot_undefined` errors in generated shaders.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f3a9617-e31d-41a8-9e89-535e89909c1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f3a9617-e31d-41a8-9e89-535e89909c1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

