### PR TITLE
Formula rendering precision and complex numbers

### DIFF
--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=14.0';
+  const SW_URL = './service-worker.js?sw=14.1';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -4,7 +4,7 @@
 import { FINGER_DECIMAL_PLACES } from './core-engine.mjs';
 
 // Bump this when changing renderer logic so users can verify cached assets.
-export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2025-12-17.2';
+export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2025-12-17.3';
 
 const DEFAULT_MATHJAX_LOAD_TIMEOUT_MS = 9000;
 
@@ -157,10 +157,11 @@ function constToLatex(node, options = {}) {
   }
 
   // Compact complex numbers to save horizontal space:
-  // Render as a 2-row array with (real ±) on top, (imag i) below.
-  // Example: ( 0.1234  + )
-  //          ( 2.0000 i   )
-  return `\\left(\\begin{array}{r c}${realLatex} & ${sign}\\\\${imag} & {}\\end{array}\\right)`;
+  // Render as "wrapped text" (not a 2-column matrix): top line ends with ±,
+  // bottom line shows the imaginary term with i.
+  // Example: ( 0.1234+ )
+  //          ( 2.0000 i )
+  return `\\left(\\substack{${realLatex}\\,${sign}\\\\${imag}}\\right)`;
 }
 
 function fingerSlotToLatex(slot) {

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -1,8 +1,10 @@
 // MathJax-based formula renderer (SVG output).
 // Produces a LaTeX string from the Reflex4You AST and renders it via MathJax.tex2svg.
 
+import { FINGER_DECIMAL_PLACES } from './core-engine.mjs';
+
 // Bump this when changing renderer logic so users can verify cached assets.
-export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2025-12-17.1';
+export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2025-12-17.2';
 
 const DEFAULT_MATHJAX_LOAD_TIMEOUT_MS = 9000;
 
@@ -38,12 +40,17 @@ function precedence(node) {
   }
 }
 
-function formatNumber(value) {
+function formatNumber(value, { decimalPlaces = FINGER_DECIMAL_PLACES, decimalSeparator = '.' } = {}) {
   if (!Number.isFinite(value)) return '?';
   const normalized = Object.is(value, -0) ? 0 : value;
   if (Number.isInteger(normalized)) return String(normalized);
-  const rounded = Math.round(normalized * 1000) / 1000;
-  return String(rounded).replace(/\.?0+$/, '');
+  const places = Math.max(0, Math.min(12, Number(decimalPlaces) || 0));
+  const factor = 10 ** places;
+  const rounded = Math.round(normalized * factor) / factor;
+  const fixed = rounded.toFixed(places).replace(/\.?0+$/, '');
+  return decimalSeparator === '.'
+    ? fixed
+    : fixed.replace('.', decimalSeparator);
 }
 
 function escapeLatexIdentifier(name) {
@@ -128,19 +135,32 @@ function maybeWrapLatex(node, latex, parentPrec, side, opKind) {
   return latex;
 }
 
-function constToLatex(node) {
+function constToLatex(node, options = {}) {
   const re = node.re;
   const im = node.im;
   if (!Number.isFinite(re) || !Number.isFinite(im)) return '?';
-  if (im === 0) return formatNumber(re);
+
+  const compactComplex = options?.compactComplexNumbers !== false;
+
+  if (im === 0) return formatNumber(re, options);
   const imagAbs = Math.abs(im);
-  const imagCoeff = imagAbs === 1 ? '' : formatNumber(imagAbs);
+  const imagCoeff = imagAbs === 1 ? '' : formatNumber(imagAbs, options);
   const imag = `${imagCoeff}${imagCoeff ? '\\,' : ''}i`;
   if (re === 0) {
     return im < 0 ? `-${imag}` : imag;
   }
+
   const sign = im >= 0 ? '+' : '-';
-  return `${formatNumber(re)} ${sign} ${imag}`;
+  const realLatex = formatNumber(re, options);
+  if (!compactComplex) {
+    return `${realLatex} ${sign} ${imag}`;
+  }
+
+  // Compact complex numbers to save horizontal space:
+  // Render as a 2-row array with (real ±) on top, (imag i) below.
+  // Example: ( 0.1234  + )
+  //          ( 2.0000 i   )
+  return `\\left(\\begin{array}{r c}${realLatex} & ${sign}\\\\${imag} & {}\\end{array}\\right)`;
 }
 
 function fingerSlotToLatex(slot) {
@@ -212,7 +232,7 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
 
   switch (node.kind) {
     case 'Const':
-      return constToLatex(node);
+      return constToLatex(node, options);
     case 'Var':
       return latexIdentifierWithMetadata(node.name || 'z', identifierHighlights(node));
     case 'VarX':
@@ -226,7 +246,7 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
       if (options && options.inlineFingerConstants) {
         const resolved = resolveFingerValue(node.slot, options);
         if (resolved) {
-          return constToLatex(resolved);
+          return constToLatex(resolved, options);
         }
       }
       return fingerSlotToLatex(node.slot);

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -2170,7 +2170,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=14.0';
+  const SW_URL = './service-worker.js?sw=14.1';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '14.0';
+const CACHE_MINOR = '14.1';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Fix finger constant precision to 4 decimal places and add compact rendering for complex numbers.

Finger constants were incorrectly truncated at 3 digits after the comma when inlined, and complex numbers with both real and imaginary parts now render in a compact stacked format to save horizontal space.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d659020-e60b-4c72-86b0-b800d3ec0028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d659020-e60b-4c72-86b0-b800d3ec0028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

