### PR TITLE
Formula constant url sync

### DIFF
--- a/apps/reflex4you/finger-url-prune.mjs
+++ b/apps/reflex4you/finger-url-prune.mjs
@@ -1,0 +1,55 @@
+/**
+ * Prune finger-related URLSearchParams so they only refer to active fingers.
+ *
+ * Reflex4You encodes:
+ * - per-finger value:   D1=1+2i
+ * - per-finger animation interval: D1A=1+2i..3+4i
+ * - shared animation time: t=5s
+ *
+ * When a formula changes, active finger labels can change. Any params for
+ * inactive fingers must be removed; otherwise stale values and animation
+ * intervals can "come back" later and unexpectedly animate.
+ */
+
+export function pruneFingerUrlParams(
+  params,
+  {
+    knownLabels = [],
+    activeLabels = [],
+    animationSuffix = 'A',
+    animationTimeParam = 't',
+  } = {},
+) {
+  if (!params || typeof params.delete !== 'function' || typeof params.has !== 'function') {
+    throw new TypeError('Expected a URLSearchParams instance');
+  }
+
+  const activeSet = new Set((activeLabels || []).filter(Boolean));
+  const labels = Array.from(new Set((knownLabels || []).filter(Boolean)));
+
+  for (const label of labels) {
+    if (activeSet.has(label)) continue;
+    params.delete(label);
+    params.delete(`${label}${animationSuffix}`);
+  }
+
+  // If no active finger has an animation interval, drop the shared timing param.
+  // This prevents stale `t=` from unexpectedly applying if animations are added back later.
+  let hasAnyActiveAnimation = false;
+  for (const label of activeSet) {
+    const key = `${label}${animationSuffix}`;
+    if (params.has(key)) {
+      const value = params.get(key);
+      if (value != null && String(value).trim() !== '') {
+        hasAnyActiveAnimation = true;
+        break;
+      }
+    }
+  }
+  if (!hasAnyActiveAnimation) {
+    params.delete(animationTimeParam);
+  }
+
+  return params;
+}
+

--- a/apps/reflex4you/finger-url-prune.test.mjs
+++ b/apps/reflex4you/finger-url-prune.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { pruneFingerUrlParams } from './finger-url-prune.mjs';
+
+test('pruneFingerUrlParams removes inactive finger values and animation intervals', () => {
+  const params = new URLSearchParams([
+    ['formula', 'z + D1'],
+    ['D1', '1+0i'],
+    ['D1A', '1+0i..2+0i'],
+    ['D2', '9+9i'],
+    ['D2A', '9+9i..8+8i'],
+    ['t', '5s'],
+    ['unrelated', 'keepme'],
+  ]);
+
+  pruneFingerUrlParams(params, {
+    knownLabels: ['D1', 'D2'],
+    activeLabels: ['D1'],
+    animationSuffix: 'A',
+    animationTimeParam: 't',
+  });
+
+  assert.equal(params.get('D1'), '1+0i');
+  assert.equal(params.get('D1A'), '1+0i..2+0i');
+  assert.equal(params.has('D2'), false);
+  assert.equal(params.has('D2A'), false);
+  assert.equal(params.get('t'), '5s');
+  assert.equal(params.get('unrelated'), 'keepme');
+});
+
+test('pruneFingerUrlParams drops t when no active animations remain', () => {
+  const params = new URLSearchParams([
+    ['D1', '1+0i'],
+    ['D1A', '1+0i..2+0i'],
+    ['t', '10s'],
+  ]);
+
+  // Formula changed: D1 no longer active, nothing active now.
+  pruneFingerUrlParams(params, {
+    knownLabels: ['D1'],
+    activeLabels: [],
+  });
+
+  assert.equal(params.has('D1'), false);
+  assert.equal(params.has('D1A'), false);
+  assert.equal(params.has('t'), false);
+});
+

--- a/apps/reflex4you/package.json
+++ b/apps/reflex4you/package.json
@@ -4,7 +4,7 @@
   "description": "Local tooling for the Reflex4You app",
   "scripts": {
     "test": "playwright test",
-    "test:node": "node --test core-engine.test.mjs parser-primitives.test.mjs arithmetic-parser.test.mjs ast-utils.test.mjs"
+    "test:node": "node --test core-engine.test.mjs parser-primitives.test.mjs arithmetic-parser.test.mjs ast-utils.test.mjs finger-url-prune.test.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.2",


### PR DESCRIPTION
Prune URL parameters for finger constants and their animations in Reflex4You to prevent stale values and unintended animations when the formula changes.

Previously, when a formula was edited to remove finger constants, the URL would retain the values and animation settings for those inactive fingers. This could lead to shared URLs animating fingers not present in the current formula or having unused parameters. This change ensures that both the finger's value (`D1=`) and its animation interval (`D1A=`) are removed if the finger is no longer active, and also removes the global animation time (`t=`) if no active animations remain.

---
<a href="https://cursor.com/background-agent?bcId=bc-b67f7c8a-c695-45b5-ba73-60b7b6017196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b67f7c8a-c695-45b5-ba73-60b7b6017196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

