### PR TITLE
Reflex4you readme version

### DIFF
--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=14.1';
+  const SW_URL = './service-worker.js?sw=15.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -570,7 +570,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v14</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v15</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -40,7 +40,7 @@ const rootElement = typeof document !== 'undefined' ? document.documentElement :
 
 let fatalErrorActive = false;
 
-const APP_VERSION = 14;
+const APP_VERSION = 15;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -2201,7 +2201,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=14.1';
+  const SW_URL = './service-worker.js?sw=15.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '14.1';
+const CACHE_MINOR = '15.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Bump the major version of `apps/reflex4you` to 15, updating all related version constants as per the app's README checklist.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4cc3804-9877-4b8b-bb28-7acc0e01e186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4cc3804-9877-4b8b-bb28-7acc0e01e186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

