### PR TITLE
Formula rendering and function lifting

### DIFF
--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -67,7 +67,7 @@ The input accepts succinct expressions with complex arithmetic, composition, and
 - **Finger tokens:** `F1`‑`F3`, `D1`‑`D3`, `W1`, `W2`.
 - **Literals:** `1.25`, `-3.5`, `2+3i`, `0,1`, `i`, `-i`, `j` (for `-½ + √3/2 i`).
 - **Operators:** `+`, `-`, `*`, `/`, power (`^` with integer exponents), composition (`o(f, g)` or `f $ g`), repeated composition (`oo(f, n)` or `f $$ n`).
-- **Functions:** `exp`, `sin`, `cos`, `tan`, `atan`, `ln`, `sqrt`, `abs`, `floor`, `conj`, `heav`. `sqrt(z, k)` desugars to `exp(0.5 * ln(z, k))`, so the optional second argument shifts the log branch; `heav(x)` evaluates to `1` when `x > 0` and `0` otherwise.
+- **Functions:** `exp`, `sin`, `cos`, `tan`, `atan`, `ln`, `sqrt`, `abs`/`modulus`, `floor`, `conj`, `heav`. `sqrt(z, k)` desugars to `exp(0.5 * ln(z, k))`, so the optional second argument shifts the log branch; `heav(x)` evaluates to `1` when `x > 0` and `0` otherwise.
 - **Conditionals:** comparisons (`<`, `<=`, `>`, `>=`, `==`), logical ops (`&&`, `||`), and `if(cond, then, else)`.
 - **Bindings:** `set name = value in body` introduces reusable values (serialized with the formula when shared).
 

--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -174,6 +174,7 @@ const BUILTIN_FUNCTION_DEFINITIONS = [
   { name: 'ln', factory: (value) => Ln(value, null) },
   { name: 'sqrt', factory: (value) => createSqrtExpression(value, null) },
   { name: 'abs', factory: Abs },
+  { name: 'modulus', factory: Abs },
   { name: 'abs2', factory: Abs2 },
   { name: 'conj', factory: Conjugate },
   { name: 'floor', factory: Floor },
@@ -299,6 +300,8 @@ const numberToken = wsRegex(NUMBER_REGEX, {
   transform: (match) => Number(match[0]),
 });
 
+// Allow underscore-highlighting on the imaginary unit so `_i` renders as a huge letter,
+// while still keeping the semantics of the imaginary unit constant.
 const imagUnit = keywordLiteral('i', { ctor: 'ImagUnit', caseSensitive: false });
 const tightImagUnit = Literal('i', { ctor: 'ImagUnitTight', caseSensitive: false });
 
@@ -314,11 +317,18 @@ const numberLiteral = numberToken.Map((value, result) => withSpan(Const(value, 0
 const imagFromNumber = numberToken.i_(tightImagUnit, { ctor: 'NumericImag' })
   .Map((magnitude, result) => withSpan(Const(0, magnitude), result.span));
 
-const unitImagLiteral = optionalSign.i_(imagUnit, { ctor: 'UnitImag' })
-  .Map((sign, result) => withSpan(Const(0, sign), result.span));
+const unitImagLiteral = Sequence([
+  optionalSign,
+  imagUnit,
+], {
+  ctor: 'UnitImag',
+  projector: (values) => ({ sign: values[0], meta: values[1] }),
+}).Map(({ sign, meta }, result) =>
+  attachIdentifierMeta(withSpan(Const(0, sign), result.span), meta),
+);
 
 const jLiteral = keywordLiteral('j', { ctor: 'ConstJ', caseSensitive: false })
-  .Map((_, result) => withSpan(Const(-0.5, SQRT3_OVER_2), result.span));
+  .Map((token, result) => attachIdentifierMeta(withSpan(Const(-0.5, SQRT3_OVER_2), result.span), token));
 
 const literalParser = Choice([
   imagFromNumber,
@@ -388,6 +398,7 @@ const RESERVED_BINDING_NAMES = new Set([
   'ln',
   'sqrt',
   'abs',
+  'modulus',
   'abs2',
   'floor',
   'conj',
@@ -497,9 +508,12 @@ const explicitComposeParser = Sequence([
 ], {
   ctor: 'ExplicitCompose',
   projector: (values) => ({ meta: values[0], first: values[2], second: values[4] }),
-}).Map(({ meta, first, second }, result) =>
-  attachIdentifierMeta(withSpan(Compose(first, second), result.span), meta),
-);
+}).Map(({ meta, first, second }, result) => {
+  const node = withSpan(Compose(first, second), result.span);
+  // Preserve the explicit call syntax for rendering (so `_o(f,g)` can show a huge "O").
+  node.__syntheticCall = { name: 'o', args: [first, second] };
+  return attachIdentifierMeta(node, meta);
+});
 
 const explicitRepeatComposeParser = createParser('ExplicitRepeatCompose', (input) => {
   const keyword = keywordLiteral('oo', { ctor: 'RepeatComposeKeyword' }).runNormalized(input);
@@ -725,7 +739,7 @@ const elementaryFunctionParser = Choice([
   ...createUnaryFunctionParsers(['acos', 'arccos'], Acos),
   lnParser,
   sqrtParser,
-  ...createUnaryFunctionParsers(['abs'], Abs),
+  ...createUnaryFunctionParsers(['abs', 'modulus'], Abs),
   ...createUnaryFunctionParsers(['abs2'], Abs2),
   ...createUnaryFunctionParsers(['floor'], Floor),
   ...createUnaryFunctionParsers(['conj'], Conjugate),
@@ -1543,50 +1557,72 @@ function eliminateTopLevelLets(ast, input) {
 }
 
 function resolveSetReferences(ast, input) {
-  const env = [];
+  const setEnv = [];
+  const letEnv = [];
+
+  function findLetBindingForName(name) {
+    for (let i = letEnv.length - 1; i >= 0; i -= 1) {
+      if (letEnv[i].name === name) {
+        return letEnv[i];
+      }
+    }
+    return null;
+  }
+
   function visit(node) {
     if (!node || typeof node !== 'object') {
       return null;
     }
     switch (node.kind) {
+      case 'LetBinding': {
+        // `let name = value in body`
+        // - `name` is in scope only for `body`
+        // - nested `let` is handled by a separate top-level validation step; still traverse.
+        const valueErr = visit(node.value);
+        if (valueErr) {
+          return valueErr;
+        }
+        letEnv.push(node);
+        const bodyErr = visit(node.body);
+        letEnv.pop();
+        return bodyErr;
+      }
       case 'SetBinding': {
         const valueErr = visit(node.value);
         if (valueErr) {
           return valueErr;
         }
-        env.push(node);
+        setEnv.push(node);
         const bodyErr = visit(node.body);
-        env.pop();
+        setEnv.pop();
         return bodyErr;
       }
       case 'Identifier': {
-        const binding = findBindingForName(env, node.name);
-        if (!binding) {
-          const span = node.span ?? input.createSpan(0, 0);
-          return new ParseFailure({
-            ctor: 'Identifier',
-            message: `Unknown variable "${node.name}". Introduce it with "set ${node.name} = value in ..."`,
-            severity: ParseSeverity.error,
-            expected: 'set binding',
-            span,
-            input: span.input || input,
-          });
+        const binding = findBindingForName(setEnv, node.name);
+        if (binding) {
+          const resolved = SetRef(node.name, binding);
+          resolved.span = node.span;
+          resolved.input = node.input;
+          Object.assign(node, resolved);
+          return null;
         }
-        const resolved = SetRef(node.name, binding);
-        resolved.span = node.span;
-        resolved.input = node.input;
-        Object.assign(node, resolved);
-        return null;
-      }
-      case 'LetBinding':
+        const letBinding = findLetBindingForName(node.name);
+        if (letBinding) {
+          // Keep the identifier node (so the renderer can still show the name),
+          // but tag it so GPU lowering can resolve it later.
+          node.__letBinding = letBinding;
+          return null;
+        }
+        const span = node.span ?? input.createSpan(0, 0);
         return new ParseFailure({
-          ctor: 'LetBinding',
-          message: 'let bindings are only allowed at the top level',
+          ctor: 'Identifier',
+          message: `Unknown variable "${node.name}". Introduce it with "set ${node.name} = value in ..."`,
           severity: ParseSeverity.error,
-          expected: 'top-level let',
-          span: node.span ?? input.createSpan(0, 0),
-          input: (node.span && node.span.input) || input,
+          expected: 'set binding',
+          span,
+          input: span.input || input,
         });
+      }
       case 'Const':
       case 'Var':
       case 'VarX':
@@ -1597,27 +1633,28 @@ function resolveSetReferences(ast, input) {
         return null;
       case 'Pow':
         return visit(node.base);
-    case 'Exp':
-    case 'Sin':
-    case 'Cos':
-    case 'Tan':
-    case 'Atan':
-    case 'Asin':
-    case 'Acos':
-    case 'Abs':
-    case 'Abs2':
-    case 'Conjugate':
-      return visit(node.value);
-    case 'Ln': {
-      const valueErr = visit(node.value);
-      if (valueErr) {
-        return valueErr;
+      case 'Exp':
+      case 'Sin':
+      case 'Cos':
+      case 'Tan':
+      case 'Atan':
+      case 'Asin':
+      case 'Acos':
+      case 'Abs':
+      case 'Abs2':
+      case 'Conjugate':
+      case 'Floor':
+        return visit(node.value);
+      case 'Ln': {
+        const valueErr = visit(node.value);
+        if (valueErr) {
+          return valueErr;
+        }
+        if (node.branch) {
+          return visit(node.branch);
+        }
+        return null;
       }
-      if (node.branch) {
-        return visit(node.branch);
-      }
-      return null;
-    }
       case 'Sub':
       case 'Mul':
       case 'Op':
@@ -1627,9 +1664,9 @@ function resolveSetReferences(ast, input) {
       case 'GreaterThan':
       case 'LessThanOrEqual':
       case 'GreaterThanOrEqual':
-    case 'Equal':
-    case 'LogicalAnd':
-    case 'LogicalOr': {
+      case 'Equal':
+      case 'LogicalAnd':
+      case 'LogicalOr': {
         const leftErr = visit(node.left);
         if (leftErr) {
           return leftErr;
@@ -1679,6 +1716,40 @@ function resolveSetReferences(ast, input) {
     }
   }
   return visit(ast);
+}
+
+function validateLetBindingsTopLevelOnly(ast, input) {
+  // Allow a chain of `LetBinding` at the root: let ... in let ... in <expr>.
+  // Disallow `LetBinding` anywhere else (inside value expressions, set bodies, etc).
+  let cursor = ast;
+  while (cursor && typeof cursor === 'object' && cursor.kind === 'LetBinding') {
+    const nested = findFirstLetBinding(cursor.value);
+    if (nested) {
+      const span = nested.span ?? input.createSpan(0, 0);
+      return new ParseFailure({
+        ctor: 'LetBinding',
+        message: 'let bindings are only allowed at the top level',
+        severity: ParseSeverity.error,
+        expected: 'top-level let',
+        span,
+        input: span.input || input,
+      });
+    }
+    cursor = cursor.body;
+  }
+  const nested = findFirstLetBinding(cursor);
+  if (nested) {
+    const span = nested.span ?? input.createSpan(0, 0);
+    return new ParseFailure({
+      ctor: 'LetBinding',
+      message: 'let bindings are only allowed at the top level',
+      severity: ParseSeverity.error,
+      expected: 'top-level let',
+      span,
+      input: span.input || input,
+    });
+  }
+  return null;
 }
 
 function findBindingForName(env, name) {
@@ -2724,15 +2795,15 @@ export function parseFormulaInput(input, options = {}) {
       input: remainder,
     });
   }
-  const letReduced = eliminateTopLevelLets(parsed.value, normalized);
-  if (letReduced instanceof ParseFailure) {
-    return letReduced;
+  const letValidationError = validateLetBindingsTopLevelOnly(parsed.value, normalized);
+  if (letValidationError instanceof ParseFailure) {
+    return letValidationError;
   }
-  const resolveError = resolveSetReferences(letReduced, normalized);
+  const resolveError = resolveSetReferences(parsed.value, normalized);
   if (resolveError instanceof ParseFailure) {
     return resolveError;
   }
-  const repeatResolved = resolveRepeatPlaceholders(letReduced, parseOptions, normalized);
+  const repeatResolved = resolveRepeatPlaceholders(parsed.value, parseOptions, normalized);
   if (repeatResolved instanceof ParseFailure) {
     return repeatResolved;
   }

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -585,6 +585,16 @@ test('_modulus(z) renders as a function call (not |z|) so the highlighted name s
   assert.match(latex, /\\left\(/);
 });
 
+test('_modulus (function literal) renders as a function call so the highlighted name shows', () => {
+  const result = parseFormulaInput('_modulus');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /\{\\Huge M\}/);
+  assert.match(latex, /\\operatorname\{/);
+  // Should render as a call on z for display (same semantics).
+  assert.match(latex, /\\left\(z\\right\)/);
+});
+
 test('nested let bindings are rejected', () => {
   const result = parseFormulaInput('set a = let f = z in f in a');
   assert.equal(result.ok, false);

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -567,6 +567,24 @@ test('_i renders as a Huge letter while keeping imaginary-unit semantics', () =>
   assert.match(latex, /\{\\Huge I\}/);
 });
 
+test('_abs(z) renders as a function call (not |z|) so the highlighted name shows', () => {
+  const result = parseFormulaInput('_abs(z)');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /\{\\Huge A\}/);
+  assert.match(latex, /\\operatorname\{/);
+  assert.match(latex, /\\left\(/);
+});
+
+test('_modulus(z) renders as a function call (not |z|) so the highlighted name shows', () => {
+  const result = parseFormulaInput('_modulus(z)');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /\{\\Huge M\}/);
+  assert.match(latex, /\\operatorname\{/);
+  assert.match(latex, /\\left\(/);
+});
+
 test('nested let bindings are rejected', () => {
   const result = parseFormulaInput('set a = let f = z in f in a');
   assert.equal(result.ok, false);

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1028,7 +1028,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=18.1';
+    const SW_URL = './service-worker.js?sw=19.1';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1028,7 +1028,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=19.2';
+    const SW_URL = './service-worker.js?sw=19.3';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1028,7 +1028,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=19.1';
+    const SW_URL = './service-worker.js?sw=19.2';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=19.1';
+  const SW_URL = './service-worker.js?sw=19.2';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=18.1';
+  const SW_URL = './service-worker.js?sw=19.1';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=19.2';
+  const SW_URL = './service-worker.js?sw=19.3';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -578,7 +578,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v18</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v19</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -2147,7 +2147,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=19.1';
+  const SW_URL = './service-worker.js?sw=19.2';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -1889,7 +1889,7 @@ async function saveCanvasImage() {
     defaultSize: defaultSize || undefined,
     includeFormulaOverlayOption: {
       label: 'Overlay formula on bottom half (with translucent white background)',
-      defaultChecked: false,
+        defaultChecked: true,
     },
   });
   if (!requested) {
@@ -2147,7 +2147,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=19.2';
+  const SW_URL = './service-worker.js?sw=19.3';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -42,7 +42,7 @@ const rootElement = typeof document !== 'undefined' ? document.documentElement :
 
 let fatalErrorActive = false;
 
-const APP_VERSION = 18;
+const APP_VERSION = 19;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -2147,7 +2147,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=18.1';
+  const SW_URL = './service-worker.js?sw=19.1';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '19.2';
+const CACHE_MINOR = '19.3';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '19.1';
+const CACHE_MINOR = '19.2';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '18.1';
+const CACHE_MINOR = '19.1';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Enhance formula rendering for `_i`, `o(f,g)`, and `let`/`set` statements, prevent render-time `let` inlining, and add `modulus` as an `abs` alias to improve visual clarity and functional consistency.

This PR addresses several user requests for the `apps/reflex4you` formula parser and renderer. `_i` now renders as a highlighted identifier, `o(f,g)` preserves its function call syntax for rendering, and `let`/`set` bindings are displayed in a more readable, program-like block format. `let` expressions are no longer inlined during rendering, and GPU compilation now handles `let`-bound functions via shared subtrees instead of full inlining. The `modulus` function was also added as a synonym for `abs`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b20cc0c2-afef-47ce-9ecf-7d56a43e6499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b20cc0c2-afef-47ce-9ecf-7d56a43e6499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

