### PR TITLE
Download size options

### DIFF
--- a/apps/reflex4you/image-export.mjs
+++ b/apps/reflex4you/image-export.mjs
@@ -220,14 +220,20 @@ export async function promptImageExportSize({
     const scales =
       typeof includeSupersampleOption === 'object' && Array.isArray(includeSupersampleOption?.scales)
         ? includeSupersampleOption.scales
-        : [2, 3, 4];
-    const normalized = Array.from(new Set(scales.map((x) => Number(x)).filter((x) => x === 2 || x === 3 || x === 4))).sort();
-    const effective = normalized.length ? normalized : [2, 3, 4];
+        : [1, 2, 3, 4];
+    const normalized = Array.from(
+      new Set(
+        scales
+          .map((x) => Number(x))
+          .filter((x) => x === 1 || x === 2 || x === 3 || x === 4),
+      ),
+    ).sort();
+    const effective = normalized.length ? normalized : [1, 2, 3, 4];
 
     for (const s of effective) {
       const opt = document.createElement('option');
       opt.value = String(s);
-      opt.textContent = `${s}×`;
+      opt.textContent = s === 1 ? 'None' : `${s}×`;
       select.appendChild(opt);
     }
 
@@ -235,7 +241,11 @@ export async function promptImageExportSize({
       typeof includeSupersampleOption === 'object' && Number(includeSupersampleOption?.defaultScale)
         ? Number(includeSupersampleOption.defaultScale)
         : 4;
-    select.value = defaultScale === 2 ? '2' : defaultScale === 3 ? '3' : '4';
+    select.value =
+      defaultScale === 1 ? '1'
+        : defaultScale === 2 ? '2'
+          : defaultScale === 3 ? '3'
+            : '4';
 
     rowSs.appendChild(left);
     rowSs.appendChild(select);

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -1886,7 +1886,7 @@ async function saveCanvasImage() {
     const screenW = clampExportPx(cssW * dpr);
     const screenH = clampExportPx(cssH * dpr);
     if (!screenW || !screenH) return [];
-    const presets = [
+    return [
       {
         key: 'screen',
         label: `Screen (${screenW}×${screenH} px)`,
@@ -1894,18 +1894,6 @@ async function saveCanvasImage() {
         height: screenH,
       },
     ];
-    // "HD" mode: supersample at 2×, then downscale for better antialiasing.
-    const canSupersample2x = screenW * 2 <= 20000 && screenH * 2 <= 20000;
-    if (canSupersample2x) {
-      presets.push({
-        key: 'screen-hd',
-        label: `HD (2× AA) (${screenW}×${screenH} px)`,
-        width: screenW,
-        height: screenH,
-        renderScale: 2,
-      });
-    }
-    return presets;
   }
 
   const defaultSize = canvas.width && canvas.height ? { width: canvas.width, height: canvas.height } : null;
@@ -1928,7 +1916,11 @@ async function saveCanvasImage() {
     title: 'Export image (PNG)',
     presets,
     defaultSize: defaultSize || undefined,
-    defaultPresetKey: 'screen-hd',
+    defaultPresetKey: 'screen',
+    includeHdOption: {
+      label: 'HD (2× AA) — render at 2× then downscale for smoother edges',
+      defaultChecked: true,
+    },
     includeFormulaOverlayOption: {
       label: 'Overlay formula on bottom half (with translucent white background)',
         defaultChecked: true,

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -1919,7 +1919,7 @@ async function saveCanvasImage() {
     defaultPresetKey: 'screen',
     includeSupersampleOption: {
       label: 'Supersampling (antialiasing)',
-      scales: [2, 3, 4],
+      scales: [1, 2, 3, 4],
       defaultScale: 4,
     },
     includeFormulaOverlayOption: {

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -1868,6 +1868,45 @@ async function saveCanvasImage() {
     return;
   }
 
+  function clampExportPx(value) {
+    const n = Math.round(Number(value));
+    if (!Number.isFinite(n)) return null;
+    return Math.max(1, Math.min(20000, n));
+  }
+
+  function screenExportPresets() {
+    if (typeof window === 'undefined') return [];
+    const viewport = window.visualViewport;
+    const cssW = Number(viewport?.width ?? window.innerWidth);
+    const cssH = Number(viewport?.height ?? window.innerHeight);
+    const dpr = Number(window.devicePixelRatio) || 1;
+    if (!Number.isFinite(cssW) || !Number.isFinite(cssH) || cssW <= 0 || cssH <= 0) {
+      return [];
+    }
+    const screenW = clampExportPx(cssW * dpr);
+    const screenH = clampExportPx(cssH * dpr);
+    if (!screenW || !screenH) return [];
+    const screen2xW = clampExportPx(screenW * 2);
+    const screen2xH = clampExportPx(screenH * 2);
+    const presets = [
+      {
+        key: 'screen',
+        label: `Screen (${screenW}×${screenH} px)`,
+        width: screenW,
+        height: screenH,
+      },
+    ];
+    if (screen2xW && screen2xH && (screen2xW !== screenW || screen2xH !== screenH)) {
+      presets.push({
+        key: 'screen-2x',
+        label: `2× Screen (${screen2xW}×${screen2xH} px)`,
+        width: screen2xW,
+        height: screen2xH,
+      });
+    }
+    return presets;
+  }
+
   const defaultSize = canvas.width && canvas.height ? { width: canvas.width, height: canvas.height } : null;
   const presets = [
     ...(defaultSize
@@ -1880,6 +1919,7 @@ async function saveCanvasImage() {
         },
       ]
       : []),
+    ...screenExportPresets(),
     ...defaultImageExportPresets(),
   ];
 


### PR DESCRIPTION
Add 'Screen' and '2× Screen' export size options to Reflex4You for saving images at device-specific resolutions.

The export size options are dynamically generated in `apps/reflex4you/main.js`, where these new options are implemented. Sizes are calculated based on the current viewport and `devicePixelRatio`, and are clamped to a maximum of 20000px per side.

---
<a href="https://cursor.com/background-agent?bcId=bc-43c7f486-b8d0-4a18-8ab8-05cbe6f7ed37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43c7f486-b8d0-4a18-8ab8-05cbe6f7ed37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

