### PR TITLE
Automated app version management

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -143,3 +143,15 @@ file:///workspace/preview.html
 ```
 https://mikaelmayer.github.io/preview.html
 ```
+
+## Reflex4You version bumping (maintenance)
+
+If you change `apps/reflex4you` and need to bump the app/cache/service-worker versions, use the one-command helper from the repo root:
+
+```bash
+npm run reflex4you:version -- major   # bump app major (APP_VERSION)
+npm run reflex4you:version -- minor   # cache/SW refresh without changing APP_VERSION
+npm run reflex4you:version -- set 20 --cache 20.1 --sw 20.2  # explicit / revert
+```
+
+Details: `apps/reflex4you/VERSIONING.md`.

--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -175,13 +175,11 @@ Use `npx playwright test --project=chromium` if you only want to debug Chromium,
 
 ## Pre-merge checklist (Reflex4You)
 
-- [ ] **Bump the app major version**: update `APP_VERSION` in `apps/reflex4you/main.js`.
-- [ ] **Keep service-worker in sync with the major version**:
-  - [ ] Update `CACHE_MINOR` in `apps/reflex4you/service-worker.js` (should start with the same major, e.g. `12.x`).
-  - [ ] Update the SW registration cache-buster query in **both** places:
-    - [ ] `apps/reflex4you/main.js` (`service-worker.js?sw=…`)
-    - [ ] `apps/reflex4you/formula-page.mjs` (`service-worker.js?sw=…`)
-- [ ] **Update any hardcoded UI version fallback**: `apps/reflex4you/index.html` (`#app-version-pill` initial text) so it matches the current major.
+- [ ] **Version bump (one command)**: from the repo root, run one of:
+  - [ ] `npm run reflex4you:version -- major` (bumps `APP_VERSION` and resets SW/cache versions)
+  - [ ] `npm run reflex4you:version -- minor` (keeps `APP_VERSION`, bumps SW/cache versions)
+  - [ ] `npm run reflex4you:version -- set …` (explicit versions / revert)
+  See `apps/reflex4you/VERSIONING.md` for details and what files are touched.
 - [ ] **PR preview cache-busting** (recommended): ensure `__REFLEX_BUILD_ID__` placeholders exist in:
   - [ ] `apps/reflex4you/index.html`
   - [ ] `apps/reflex4you/formula.html`

--- a/apps/reflex4you/VERSIONING.md
+++ b/apps/reflex4you/VERSIONING.md
@@ -1,0 +1,53 @@
+## Reflex4You versioning (for agents)
+
+Reflex4You has **three** separate but related “version” knobs that must stay consistent:
+
+- **`APP_VERSION`** (integer) in `apps/reflex4you/main.js`  
+  - This is the **app major** shown to users (`v20`, `v21`, …) and used in local-storage keys.
+- **`CACHE_MINOR`** (string `M.m`) in `apps/reflex4you/service-worker.js`  
+  - This controls the **CacheStorage names**. Bump it when you need clients to fetch a fresh precache.
+- **Service worker registration URL** cache-buster (`service-worker.js?sw=M.m`)  
+  - Appears in `main.js`, `formula-page.mjs`, and `explore-page.mjs`. Bump it to ensure browsers don’t keep using a cached SW script.
+
+To avoid missing one of these, use the repo-local one-command tool:
+
+```bash
+# From repo root:
+npm run reflex4you:version -- major
+```
+
+### Supported operations
+
+- **Bump major (app version)**:
+
+```bash
+npm run reflex4you:version -- major
+```
+
+- **Bump minor (cache + SW refresh only)**:
+
+```bash
+npm run reflex4you:version -- minor
+```
+
+- **Set an explicit version (useful for reverts)**:
+
+```bash
+# Set app major and (optionally) explicit cache/SW versions.
+npm run reflex4you:version -- set 20 --cache 20.1 --sw 20.2
+```
+
+### What the command edits
+
+- `apps/reflex4you/main.js`
+  - `APP_VERSION = …`
+  - `service-worker.js?sw=…`
+- `apps/reflex4you/service-worker.js`
+  - `CACHE_MINOR = '…'`
+- `apps/reflex4you/formula-page.mjs`
+  - `service-worker.js?sw=…`
+- `apps/reflex4you/explore-page.mjs`
+  - `service-worker.js?sw=…`
+- `apps/reflex4you/index.html`
+  - `#app-version-pill` fallback text (`v…`)
+

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1028,7 +1028,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=20.2';
+    const SW_URL = './service-worker.js?sw=21.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=20.2';
+  const SW_URL = './service-worker.js?sw=21.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -831,7 +831,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v20</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v21</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -42,7 +42,7 @@ const rootElement = typeof document !== 'undefined' ? document.documentElement :
 
 let fatalErrorActive = false;
 
-const APP_VERSION = 20;
+const APP_VERSION = 21;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -2844,7 +2844,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=20.2';
+  const SW_URL = './service-worker.js?sw=21.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '20.1';
+const CACHE_MINOR = '21.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "playwright test"
+    "test": "playwright test",
+    "reflex4you:version": "node scripts/reflex4you-version.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/reflex4you-version.mjs
+++ b/scripts/reflex4you-version.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+/**
+ * Reflex4You version sync tool.
+ *
+ * Single entry point to keep these in sync:
+ * - apps/reflex4you/main.js          (APP_VERSION + SW URL cache buster)
+ * - apps/reflex4you/service-worker.js (CACHE_MINOR)
+ * - apps/reflex4you/formula-page.mjs  (SW URL cache buster)
+ * - apps/reflex4you/explore-page.mjs  (SW URL cache buster)
+ * - apps/reflex4you/index.html        (#app-version-pill fallback text)
+ *
+ * Usage:
+ *   npm run reflex4you:version -- major
+ *   npm run reflex4you:version -- minor
+ *   npm run reflex4you:version -- set 21 --cache 21.0 --sw 21.0
+ *   npm run reflex4you:version -- set 20 --cache 20.1 --sw 20.2   # revert example
+ *   npm run reflex4you:version -- --dry-run major
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const APP_DIR = path.join(REPO_ROOT, 'apps', 'reflex4you');
+
+const FILES = {
+  mainJs: path.join(APP_DIR, 'main.js'),
+  swJs: path.join(APP_DIR, 'service-worker.js'),
+  formulaPage: path.join(APP_DIR, 'formula-page.mjs'),
+  explorePage: path.join(APP_DIR, 'explore-page.mjs'),
+  indexHtml: path.join(APP_DIR, 'index.html'),
+};
+
+function die(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const dryRunIdx = args.indexOf('--dry-run');
+  const dryRun = dryRunIdx !== -1;
+  if (dryRun) args.splice(dryRunIdx, 1);
+
+  const help = args.includes('-h') || args.includes('--help');
+  if (help || args.length === 0) {
+    return { help: true, dryRun };
+  }
+
+  const action = args[0];
+  const rest = args.slice(1);
+
+  const flags = {};
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--app') flags.app = rest[++i];
+    else if (a === '--cache') flags.cache = rest[++i];
+    else if (a === '--sw') flags.sw = rest[++i];
+    else if (flags._) flags._.push(a);
+    else flags._ = [a];
+  }
+  return { help: false, dryRun, action, flags };
+}
+
+function parseIntStrict(value, label) {
+  if (value == null) die(`Missing ${label}.`);
+  const n = Number(String(value).trim());
+  if (!Number.isInteger(n) || n < 0) die(`Invalid ${label}: ${value}`);
+  return n;
+}
+
+function parseMajorMinor(value, label) {
+  if (value == null) die(`Missing ${label}.`);
+  const raw = String(value).trim();
+  const m = /^(\d+)\.(\d+)$/.exec(raw);
+  if (!m) die(`Invalid ${label} (expected M.m): ${value}`);
+  return { major: Number(m[1]), minor: Number(m[2]), raw };
+}
+
+function replaceOnce(text, regex, replacement, labelForError) {
+  if (!regex.test(text)) {
+    die(`Failed to update ${labelForError} (pattern not found).`);
+  }
+  return text.replace(regex, replacement);
+}
+
+function computeNext({ action, flags, current }) {
+  if (action === 'major') {
+    const nextApp = current.appMajor + 1;
+    const nextCache = { major: nextApp, minor: 0, raw: `${nextApp}.0` };
+    const nextSw = { major: nextApp, minor: 0, raw: `${nextApp}.0` };
+    return { appMajor: nextApp, cache: nextCache, sw: nextSw };
+  }
+
+  if (action === 'minor') {
+    const major = current.appMajor;
+    const nextMinor = Math.max(current.cache.minor, current.sw.minor) + 1;
+    const next = { major, minor: nextMinor, raw: `${major}.${nextMinor}` };
+    return { appMajor: major, cache: next, sw: next };
+  }
+
+  if (action === 'set') {
+    const positional = flags._ || [];
+    const app = flags.app ?? positional[0];
+    const appMajor = parseIntStrict(app, 'app major version');
+
+    const cache = flags.cache ? parseMajorMinor(flags.cache, '--cache') : { major: appMajor, minor: 0, raw: `${appMajor}.0` };
+    const sw = flags.sw ? parseMajorMinor(flags.sw, '--sw') : { major: appMajor, minor: 0, raw: `${appMajor}.0` };
+
+    if (cache.major !== appMajor) die(`--cache major (${cache.major}) must match app major (${appMajor}).`);
+    if (sw.major !== appMajor) die(`--sw major (${sw.major}) must match app major (${appMajor}).`);
+    return { appMajor, cache, sw };
+  }
+
+  die(`Unknown action: ${action}\nExpected: major | minor | set`);
+}
+
+function printHelp() {
+  console.log(
+    [
+      'Reflex4You version sync tool',
+      '',
+      'Usage:',
+      '  npm run reflex4you:version -- major',
+      '  npm run reflex4you:version -- minor',
+      '  npm run reflex4you:version -- set 21 --cache 21.0 --sw 21.0',
+      '  npm run reflex4you:version -- set 20 --cache 20.1 --sw 20.2   # revert example',
+      '  npm run reflex4you:version -- --dry-run major',
+      '',
+      'What it updates:',
+      '  - apps/reflex4you/main.js: APP_VERSION + service-worker.js?sw=…',
+      "  - apps/reflex4you/service-worker.js: CACHE_MINOR = 'M.m'",
+      '  - apps/reflex4you/formula-page.mjs: service-worker.js?sw=…',
+      '  - apps/reflex4you/explore-page.mjs: service-worker.js?sw=…',
+      '  - apps/reflex4you/index.html: #app-version-pill fallback vM',
+      '',
+      'Actions:',
+      '  - major: APP_VERSION++, set cache+sw to (M.0)',
+      '  - minor: keep APP_VERSION, bump cache+sw to next minor (M.(max+1))',
+      '  - set: explicitly set versions (useful for reverts)',
+    ].join('\n'),
+  );
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv);
+  if (parsed.help) {
+    printHelp();
+    return;
+  }
+
+  const [mainJs, swJs, formulaPage, explorePage, indexHtml] = await Promise.all([
+    fs.readFile(FILES.mainJs, 'utf8'),
+    fs.readFile(FILES.swJs, 'utf8'),
+    fs.readFile(FILES.formulaPage, 'utf8'),
+    fs.readFile(FILES.explorePage, 'utf8'),
+    fs.readFile(FILES.indexHtml, 'utf8'),
+  ]);
+
+  const appMatch = /const\s+APP_VERSION\s*=\s*(\d+)\s*;/.exec(mainJs);
+  if (!appMatch) die('Could not find APP_VERSION in apps/reflex4you/main.js');
+  const appMajor = Number(appMatch[1]);
+
+  const cacheMatch = /const\s+CACHE_MINOR\s*=\s*'(\d+\.\d+)'\s*;/.exec(swJs);
+  if (!cacheMatch) die("Could not find CACHE_MINOR = 'M.m' in apps/reflex4you/service-worker.js");
+  const cache = parseMajorMinor(cacheMatch[1], 'CACHE_MINOR');
+
+  const swMatch = /service-worker\.js\?sw=(\d+\.\d+)/.exec(mainJs);
+  if (!swMatch) die('Could not find service-worker.js?sw=… in apps/reflex4you/main.js');
+  const sw = parseMajorMinor(swMatch[1], 'SW_URL');
+
+  // If the repo is already in a mismatched state, only `set` is allowed so we can repair it.
+  if (parsed.action !== 'set' && (cache.major !== appMajor || sw.major !== appMajor)) {
+    die(
+      [
+        'Reflex4You version mismatch detected:',
+        `- APP_VERSION=${appMajor}`,
+        `- CACHE_MINOR=${cache.raw}`,
+        `- SW_URL=${sw.raw}`,
+        '',
+        'Refusing to proceed automatically. Use:',
+        '  npm run reflex4you:version -- set <APP_VERSION> --cache <M.m> --sw <M.m>',
+      ].join('\n'),
+    );
+  }
+
+  const next = computeNext({ action: parsed.action, flags: parsed.flags, current: { appMajor, cache, sw } });
+
+  const updatedMainJs = (() => {
+    let text = mainJs;
+    text = replaceOnce(
+      text,
+      /const\s+APP_VERSION\s*=\s*\d+\s*;/,
+      `const APP_VERSION = ${next.appMajor};`,
+      'APP_VERSION in apps/reflex4you/main.js',
+    );
+    // Keep any existing sw=… occurrences in sync.
+    text = text.replace(/service-worker\.js\?sw=\d+\.\d+/g, `service-worker.js?sw=${next.sw.raw}`);
+    return text;
+  })();
+
+  const updatedSwJs = replaceOnce(
+    swJs,
+    /const\s+CACHE_MINOR\s*=\s*'\d+\.\d+'\s*;/,
+    `const CACHE_MINOR = '${next.cache.raw}';`,
+    'CACHE_MINOR in apps/reflex4you/service-worker.js',
+  );
+
+  const updateSwUrlIn = (text, label) => {
+    const re = /service-worker\.js\?sw=\d+\.\d+/g;
+    if (!re.test(text)) die(`Failed to update service-worker.js?sw=… in ${label}`);
+    return text.replace(re, `service-worker.js?sw=${next.sw.raw}`);
+  };
+
+  const updatedFormulaPage = updateSwUrlIn(formulaPage, 'apps/reflex4you/formula-page.mjs');
+  const updatedExplorePage = updateSwUrlIn(explorePage, 'apps/reflex4you/explore-page.mjs');
+
+  const updatedIndexHtml = (() => {
+    let text = indexHtml;
+    // Update the fallback pill content (JS will override after load).
+    text = replaceOnce(
+      text,
+      /(<div\s+id="app-version-pill"[^>]*>\s*)v\d+(\s*<\/div>)/,
+      `$1v${next.appMajor}$2`,
+      'fallback #app-version-pill text in apps/reflex4you/index.html',
+    );
+    return text;
+  })();
+
+  const plan = [
+    `APP_VERSION: ${appMajor} -> ${next.appMajor}`,
+    `CACHE_MINOR: ${cache.raw} -> ${next.cache.raw}`,
+    `SW_URL (sw=): ${sw.raw} -> ${next.sw.raw}`,
+  ].join('\n');
+
+  if (parsed.dryRun) {
+    console.log('[dry-run] Would apply:\n' + plan);
+    return;
+  }
+
+  await Promise.all([
+    fs.writeFile(FILES.mainJs, updatedMainJs, 'utf8'),
+    fs.writeFile(FILES.swJs, updatedSwJs, 'utf8'),
+    fs.writeFile(FILES.formulaPage, updatedFormulaPage, 'utf8'),
+    fs.writeFile(FILES.explorePage, updatedExplorePage, 'utf8'),
+    fs.writeFile(FILES.indexHtml, updatedIndexHtml, 'utf8'),
+  ]);
+
+  console.log('Updated Reflex4You versions:\n' + plan);
+}
+
+main().catch((err) => die(err?.stack || String(err)));
+


### PR DESCRIPTION
Adds a one-command utility to manage `apps/reflex4you` versions, bumping its major version from `v20` to `v21`.

The `apps/reflex4you` application previously required manual updates across multiple files (`main.js`, `service-worker.js`, `formula-page.mjs`, `explore-page.mjs`, `index.html`) to keep `APP_VERSION`, `CACHE_MINOR`, and service worker cache-buster URLs in sync. This PR introduces a `npm run reflex4you:version` command to streamline these updates and documents its usage for other agents.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5c97a9a-c712-429a-9f5d-0ddc882d8ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5c97a9a-c712-429a-9f5d-0ddc882d8ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

