### PR TITLE
Formula rendering fix

### DIFF
--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -1850,6 +1850,16 @@ function resolveRepeatPlaceholders(ast, parseOptions, input) {
       return null;
     }
     switch (node.kind) {
+      case 'LetBinding': {
+        // `let` bindings can appear at the top level and may contain `$$` nodes
+        // in their bodies. We must traverse them so `RepeatComposePlaceholder`
+        // nodes are resolved into `ComposeMultiple` before GPU compilation.
+        const valueErr = visit(node.value, node, 'value');
+        if (valueErr) {
+          return valueErr;
+        }
+        return visit(node.body, node, 'body');
+      }
       case 'RepeatComposePlaceholder': {
         const baseErr = visit(node.base, node, 'base');
         if (baseErr) {
@@ -1896,6 +1906,7 @@ function resolveRepeatPlaceholders(ast, parseOptions, input) {
         return bodyErr;
       }
       case 'SetRef':
+      case 'Identifier':
       case 'Const':
       case 'Var':
       case 'VarX':

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -264,6 +264,17 @@ test('$$ postfix binds tighter than $', () => {
   assert.equal(result.value.f.resolvedCount, 2);
 });
 
+test('$$ resolves inside top-level let bindings', () => {
+  const result = parseFormulaInput('let g = z^2 - D1 in g $$ 8');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'LetBinding');
+  assert.equal(result.value.name, 'g');
+  assert.equal(result.value.body.kind, 'ComposeMultiple');
+  assert.equal(result.value.body.resolvedCount, 8);
+  assert.equal(result.value.body.base.kind, 'Identifier');
+  assert.equal(result.value.body.base.name, 'g');
+});
+
 test('$$ accepts zero counts as identity', () => {
   const result = parseFormulaInput('z $$ 0');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1028,7 +1028,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=21.0';
+    const SW_URL = './service-worker.js?sw=22.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=21.0';
+  const SW_URL = './service-worker.js?sw=22.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -831,7 +831,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v21</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v22</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -42,7 +42,7 @@ const rootElement = typeof document !== 'undefined' ? document.documentElement :
 
 let fatalErrorActive = false;
 
-const APP_VERSION = 21;
+const APP_VERSION = 22;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -2844,7 +2844,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=21.0';
+  const SW_URL = './service-worker.js?sw=22.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '21.0';
+const CACHE_MINOR = '22.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Fix `$$` operator to correctly iterate functions within `let` bindings and bumps major version.

The `RepeatComposePlaceholder` for `$$` was not being resolved when inside `LetBinding` nodes, causing `g $$ 8` to behave like `g $$ 1`. This fix adds traversal for `LetBinding` nodes during placeholder resolution, ensuring `$$` resolves to the correct repeat count.

---
<a href="https://cursor.com/background-agent?bcId=bc-2efe86ee-3885-4522-bc18-8c645e8ff968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2efe86ee-3885-4522-bc18-8c645e8ff968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

