### PR TITLE
Fractal computation GPU issue

### DIFF
--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -104,6 +104,20 @@ test('buildFragmentSourceFromAST does not mutate repeat-composition (ComposeMult
   assert.equal(latexAfter, latexBefore);
 });
 
+test('buildFragmentSourceFromAST does not silently drop legacy RepeatComposePlaceholder nodes', () => {
+  // This node kind should normally be resolved during parsing, but shader generation
+  // must not compile it as just the base when the count is a literal.
+  const legacy = {
+    kind: 'RepeatComposePlaceholder',
+    base: { kind: 'Var', name: 'z' },
+    countExpression: { kind: 'Const', re: 8, im: 0 },
+  };
+  const fragment = buildFragmentSourceFromAST(legacy);
+  const matches = fragment.match(/return\s+node\d+\(node\d+\(z\)\);/g) || [];
+  // oo(f, 8) produces 7 Compose wrappers in the materialized tree.
+  assert.equal(matches.length, 7);
+});
+
 test('Pow nodes emit exponentiation by squaring and allow negatives', () => {
   const ast = Pow(Const(1, 0), -3);
   const fragment = buildFragmentSourceFromAST(ast);


### PR DESCRIPTION
Hardens GPU shader materialization to prevent `$$` (repeated composition) from being dropped when used with `let` bindings.

The GPU shader materialization pipeline was silently ignoring `RepeatComposePlaceholder` nodes if they weren't fully resolved into `ComposeMultiple` nodes, leading to incorrect rendering where repeated compositions were not applied. This fix ensures that `$$ n` expressions with literal `n` counts are correctly expanded into chained compositions, even if the placeholder resolution step is incomplete.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9caf522-bb89-4a66-9633-9b47b14790c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9caf522-bb89-4a66-9633-9b47b14790c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

