### PR TITLE
Isnan function support

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -397,6 +397,21 @@ test('parses abs2() calls as unary functions', () => {
   assert.equal(result.value.value.kind, 'Var');
 });
 
+test('parses isnan() calls as an error predicate', () => {
+  const result = parseFormulaInput('isnan(z)');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'IsNaN');
+  assert.equal(result.value.value.kind, 'Var');
+});
+
+test('allows isnan to be referenced as a built-in function value', () => {
+  const result = parseFormulaInput('isnan $ z');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Compose');
+  assert.equal(result.value.f.kind, 'IsNaN');
+  assert.equal(result.value.g.kind, 'Var');
+});
+
 test('allows built-in functions to be referenced as values', () => {
   const result = parseFormulaInput('abs $ z');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -404,6 +404,20 @@ test('parses isnan() calls as an error predicate', () => {
   assert.equal(result.value.value.kind, 'Var');
 });
 
+test('parses ifnan(value, fallback) as a single-evaluation error guard', () => {
+  const result = parseFormulaInput('ifnan(z/0, 7)');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'IfNaN');
+  assert.equal(result.value.value.kind, 'Div');
+  assert.equal(result.value.fallback.kind, 'Const');
+});
+
+test('parses iferror as a synonym for ifnan', () => {
+  const result = parseFormulaInput('iferror(z/0, 7)');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'IfNaN');
+});
+
 test('allows isnan to be referenced as a built-in function value', () => {
   const result = parseFormulaInput('isnan $ z');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -36,6 +36,7 @@ export function childEntries(node) {
     case 'Abs2':
     case 'Floor':
     case 'Conjugate':
+    case 'IsNaN':
       return [['value', node.value]];
     case 'Ln': {
       const entries = [['value', node.value]];

--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -77,6 +77,11 @@ export function childEntries(node) {
         ['thenBranch', node.thenBranch],
         ['elseBranch', node.elseBranch],
       ];
+    case 'IfNaN':
+      return [
+        ['value', node.value],
+        ['fallback', node.fallback],
+      ];
     case 'SetBinding':
       return [
         ['value', node.value],

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -11,6 +11,7 @@ import {
   Offset,
   Offset2,
   Add,
+  Div,
   Compose,
   Const,
   Pow,
@@ -36,6 +37,7 @@ import {
   Abs2,
   Floor,
   Conjugate,
+  IsNaN,
   buildFragmentSourceFromAST,
 } from './core-engine.mjs';
 
@@ -215,6 +217,14 @@ test('Conjugate nodes flip the imaginary component', () => {
   const fragment = buildFragmentSourceFromAST(ast);
   assert.match(fragment, /vec2 inner =/);
   assert.match(fragment, /vec2\(inner\.x, -inner\.y\)/);
+});
+
+test('isnan() nodes emit the error predicate helper and boolean output', () => {
+  const ast = IsNaN(Div(Const(1, 0), Const(0, 0)));
+  const fragment = buildFragmentSourceFromAST(ast);
+  assert.match(fragment, /float c_is_error\(vec2 z\)/);
+  assert.match(fragment, /c_is_error\(inner\)/);
+  assert.match(fragment, /return vec2\(flag, 0\.0\);/);
 });
 
 test('LessThan nodes compare real parts and emit boolean constants', () => {

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -33,6 +33,7 @@ import {
   LogicalAnd,
   LogicalOr,
   If,
+  IfNaN,
   Abs,
   Abs2,
   Floor,
@@ -273,6 +274,15 @@ test('If nodes branch based on non-zero condition', () => {
   assert.match(fragment, /vec2 cond =/);
   assert.match(fragment, /bool selector =/);
   assert.match(fragment, /if \(selector\)/);
+});
+
+test('ifnan(value, fallback) evaluates value once and returns it when not error', () => {
+  const ast = IfNaN(Div(VarZ(), Const(0, 0)), Const(7, 0));
+  const fragment = buildFragmentSourceFromAST(ast);
+  // Compiles via local `inner` (avoids recomputing the value expression).
+  assert.match(fragment, /vec2 inner = node\d+\(z\);/);
+  assert.match(fragment, /float flag = c_is_error\(inner\);/);
+  assert.match(fragment, /return inner;/);
 });
 
 test('Abs nodes emit magnitude as real output', () => {

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -13,6 +13,7 @@ function precedence(node) {
   switch (node.kind) {
     case 'SetBinding':
     case 'If':
+    case 'IfNaN':
       return 1;
     case 'LogicalOr':
       return 2;

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -315,6 +315,8 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
       return `\\left\\lfloor${nodeToLatex(node.value, 0, options)}\\right\\rfloor`;
     case 'Conjugate':
       return `\\overline{${nodeToLatex(node.value, 0, options)}}`;
+    case 'IsNaN':
+      return functionCallLatex('isnan', [node.value], options, identifierHighlights(node));
 
     case 'Add':
     case 'Sub':


### PR DESCRIPTION
Add `isnan` function to `apps/reflex4you` to return 1 for error values (NaN/overflow) and 0 otherwise, with full parser, AST, and GPU code generation support.

---
<a href="https://cursor.com/background-agent?bcId=bc-57387ac9-3e10-4052-8ce9-48632a5627d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57387ac9-3e10-4052-8ce9-48632a5627d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces error-handling primitives to the formula language and ensures end-to-end support.
> 
> - Adds AST nodes and constructors: `IsNaN(value)` and `IfNaN(value, fallback)`; wires them into traversal, cloning, substitution, validation, constant evaluation, GPU lowering, and node ID/collection utilities
> - Extends parser: unary `isnan(expr)`; binary `ifnan(value, fallback)` and alias `iferror(...)`; reserves identifiers; supports built-in literal for `isnan`; preserves call syntax metadata for aliases
> - Updates GLSL generation: emits `c_is_error` helper and codegen for `IsNaN` (boolean as `vec2(flag,0)`) and `IfNaN` (single-evaluation guard); integrates into fragment template
> - Updates renderer/LaTeX: precedence includes `IfNaN`; renders `isnan(...)` calls
> - Adds comprehensive tests for parsing, GLSL output, and behavior of new nodes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 107515140dc70ea26b5867e206b8bb809fef9ca8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->