### PR TITLE
Formula computation performance

### DIFF
--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1028,7 +1028,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=24.1';
+    const SW_URL = './service-worker.js?sw=25.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1028,7 +1028,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=24.0';
+    const SW_URL = './service-worker.js?sw=24.1';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-compile-worker.mjs
+++ b/apps/reflex4you/formula-compile-worker.mjs
@@ -1,0 +1,44 @@
+import { parseFormulaInput } from './arithmetic-parser.mjs';
+import { formatCaretIndicator } from './parse-error-format.mjs';
+import { compileFormulaForGpu } from './core-engine.mjs';
+
+self.onmessage = (event) => {
+  const payload = event?.data || {};
+  const id = payload.id;
+  const source = String(payload.source || '');
+  const fingerValues = payload.fingerValues && typeof payload.fingerValues === 'object' ? payload.fingerValues : {};
+
+  try {
+    const result = parseFormulaInput(source, { fingerValues });
+    if (!result.ok) {
+      self.postMessage({
+        id,
+        ok: false,
+        caretMessage: formatCaretIndicator(source, result),
+      });
+      return;
+    }
+
+    const ast = result.value;
+    const compiled = compileFormulaForGpu(ast);
+    self.postMessage({
+      id,
+      ok: true,
+      ast,
+      gpuAst: compiled.gpuAst,
+      fragmentSource: compiled.fragmentSource,
+      uniformCounts: compiled.uniformCounts,
+    });
+  } catch (error) {
+    const message =
+      error && typeof error.message === 'string'
+        ? error.message
+        : String(error || 'Unknown error');
+    self.postMessage({
+      id,
+      ok: false,
+      caretMessage: `Compilation error:\n${message}`,
+    });
+  }
+};
+

--- a/apps/reflex4you/formula-compile-worker.mjs
+++ b/apps/reflex4you/formula-compile-worker.mjs
@@ -24,8 +24,6 @@ self.onmessage = (event) => {
     self.postMessage({
       id,
       ok: true,
-      ast,
-      gpuAst: compiled.gpuAst,
       fragmentSource: compiled.fragmentSource,
       uniformCounts: compiled.uniformCounts,
     });

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=24.0';
+  const SW_URL = './service-worker.js?sw=24.1';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=24.1';
+  const SW_URL = './service-worker.js?sw=25.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -847,10 +847,72 @@
       cursor: pointer;
       touch-action: manipulation;
     }
+
+    /* Lightweight compile/loading overlay (shown on cold start + recompiles). */
+    #compile-overlay {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9000;
+      pointer-events: none; /* never block editing/gestures */
+      background: rgba(0, 0, 0, 0.35);
+      opacity: 1;
+      transition: opacity 0.18s ease;
+    }
+
+    #compile-overlay[data-visible="false"] {
+      opacity: 0;
+      display: none;
+    }
+
+    .compile-overlay__card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 16px;
+      border-radius: 14px;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      background: rgba(0, 0, 0, 0.70);
+      box-shadow: 0 18px 50px rgba(0, 0, 0, 0.55);
+      max-width: min(86vw, 520px);
+    }
+
+    .compile-overlay__spinner {
+      width: 34px;
+      height: 34px;
+      border-radius: 999px;
+      border: 3px solid rgba(255, 255, 255, 0.18);
+      border-top-color: rgba(158, 240, 255, 0.95);
+      animation: compile-overlay-spin 0.9s linear infinite;
+    }
+
+    @keyframes compile-overlay-spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+
+    #compile-overlay-text {
+      font-size: 13px;
+      letter-spacing: 0.02em;
+      color: rgba(255, 255, 255, 0.86);
+      text-align: center;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      white-space: pre-wrap;
+    }
   </style>
 </head>
 <body>
 <canvas id="glcanvas"></canvas>
+
+<div id="compile-overlay" data-visible="true" aria-live="polite" aria-hidden="false">
+  <div class="compile-overlay__card">
+    <div class="compile-overlay__spinner" aria-hidden="true"></div>
+    <div id="compile-overlay-text">Loading…</div>
+  </div>
+</div>
 
 <div id="finger-overlay" aria-hidden="true"></div>
 

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1025,7 +1025,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v24</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v25</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -57,7 +57,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 24;
+const APP_VERSION = 25;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -2439,6 +2439,9 @@ async function bootstrapReflexApplication() {
     canvas.style.pointerEvents = 'none';
   }
 
+  // Cold-start overlay: hide once boot is complete (success or failure).
+  setCompileOverlayVisible(false);
+
   // Track active pointers so we can snapshot only when all fingers are released.
   if (canvas && typeof window !== 'undefined') {
     canvas.addEventListener('pointerdown', (event) => {
@@ -3631,7 +3634,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=24.1';
+  const SW_URL = './service-worker.js?sw=25.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '24.1';
+const CACHE_MINOR = '25.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '24.0';
+const CACHE_MINOR = '24.1';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope
@@ -30,6 +30,7 @@ const PRECACHE_URLS = [
   './icon-512.png',
   './Screenshot_20251213-082055.png',
   './main.js',
+  './formula-compile-worker.mjs',
   './menu-ui.mjs',
   './anim-utils.mjs',
   './explore-page.mjs',


### PR DESCRIPTION
Add a loading animation and move formula compilation to a Web Worker with "latest-wins" cancellation to prevent UI freezes during complex formula loading and editing.

The UI previously froze because formula parsing and WebGL program rebuilding occurred synchronously on the main thread with every keystroke. This change offloads the heavy compilation work to a Web Worker, debounces input, and defers the final shader swap to idle time, ensuring the UI remains responsive during active typing. It also terminates any in-progress compilations when a new edit occurs, guaranteeing only the latest formula is processed.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3d77c5d-52c4-4d51-87ae-c312fd5e9b5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3d77c5d-52c4-4d51-87ae-c312fd5e9b5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves heavy formula compilation off the main thread and wires an async, latest-wins pipeline to keep typing and gestures responsive.
> 
> - Adds `apps/reflex4you/formula-compile-worker.mjs` and main-thread plumbing (`requestWorkerCompile`, debounce, idle shader swap, termination) in `main.js`
> - Introduces `ReflexCore.setCompiledFormula` and `rebuildProgramFromCompiled`; `compileFormulaForGpu` now returns `{ fragmentSource, uniformCounts, gpuAst }`; `buildFragmentSourceFromAST` delegates to it
> - UI: adds a lightweight compile overlay (`#compile-overlay`) with spinner; shown on cold start and while compiling; hides after successful apply
> - Editing flow: commits history only after successful async apply; keeps share URL in sync immediately while deferring compressed upgrade
> - Service worker/cache: bump to `25.0`, update registration URLs, and precache `formula-compile-worker.mjs`; version pill shows `v25`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b401d835afbb8fba7dc96484ca39535aa7f58e95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->