### PR TITLE
Shared animation parameters sync

### DIFF
--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -802,10 +802,6 @@ async function animateTopToFingers(targetFingers, { durationMs } = {}) {
   const token = ++pendingTransitionToken;
   isTransitioning = true;
   pushUiFreeze();
-  const shouldResumeAnimations = Boolean(animationController?.isPlaying?.());
-  if (shouldResumeAnimations) {
-    animationController.pause();
-  }
 
   try {
     const from = readFingersFromCore(topCore, activeLabels);
@@ -853,9 +849,6 @@ async function animateTopToFingers(targetFingers, { durationMs } = {}) {
   } finally {
     isTransitioning = false;
     popUiFreeze();
-    if (shouldResumeAnimations) {
-      animationController.resume();
-    }
   }
 }
 

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1295,7 +1295,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=26.0';
+    const SW_URL = './service-worker.js?sw=27.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -21,6 +21,11 @@ const TOP_FRACTION = 2 / 3;
 // Number of miniature choices (excluding refresh).
 const THUMB_COUNT = 7;
 
+// Keep URL-driven parameter animations consistent with index.html.
+const ANIMATION_SUFFIX = 'A';
+const ANIMATION_TIME_PARAM = 't';
+const DEFAULT_ANIMATION_SECONDS = 5;
+
 // View transition timing: seconds per unit of RMS finger distance.
 // Example: distance 1 => 1 second when set to 1.
 const TRANSITION_SECONDS_PER_DISTANCE = 1;
@@ -79,6 +84,16 @@ const W_PAIR_LEGACY = ['W1', 'W2'];
 
 function isFingerLabel(label) {
   return typeof label === 'string' && FINGER_LABEL_REGEX.test(label);
+}
+
+function parseSecondsFromQuery(raw) {
+  if (raw == null) return null;
+  const trimmed = String(raw).trim().toLowerCase();
+  if (!trimmed) return null;
+  const numeric = trimmed.endsWith('s') ? trimmed.slice(0, -1) : trimmed;
+  const seconds = Number(numeric);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return seconds;
 }
 
 function fingerFamily(label) {
@@ -174,6 +189,24 @@ function parseComplexString(raw) {
     return { x: realValue, y: 0 };
   }
   return null;
+}
+
+function parseComplexInterval(raw) {
+  if (!raw) return null;
+  const normalized = String(raw).trim().replace(/\s+/g, '');
+  if (!normalized || normalized.includes(';') || normalized.includes('|')) return null;
+  const parts = normalized.split('..');
+  if (parts.length !== 2) return null;
+  const start = parseComplexString(parts[0]);
+  const end = parseComplexString(parts[1]);
+  if (!start || !end) return null;
+  return { start, end };
+}
+
+function readAnimationIntervalFromQuery(label) {
+  const params = new URLSearchParams(window.location.search);
+  const key = `${label}${ANIMATION_SUFFIX}`;
+  return parseComplexInterval(params.get(key));
 }
 
 const FINGER_DECIMAL_FACTOR = 10 ** FINGER_DECIMAL_PLACES;
@@ -481,6 +514,11 @@ let activeFingerConfig = { fixedSlots: [], dynamicSlots: [], wSlots: [], axisCon
 let solosPresent = false;
 let soloLabelSet = new Set();
 
+let animationSeconds = DEFAULT_ANIMATION_SECONDS;
+let animationController = null;
+let animatedLabelSet = new Set();
+let latestAnimatedValues = new Map(); // label -> { x, y }
+
 let isTransitioning = false;
 let pendingTransitionToken = 0;
 
@@ -556,12 +594,134 @@ function readFingersFromCore(core, labels) {
   return fingers;
 }
 
-function applyFingersToCore(core, fingers) {
-  for (const label of activeLabels) {
+function applyFingersToCore(core, fingers, { ignoreLabels = null } = {}) {
+  const ignore = ignoreLabels instanceof Set ? ignoreLabels : null;
+  for (const label of allUsedLabels) {
+    if (ignore && ignore.has(label)) continue;
     const v = fingers[label];
     if (!v) continue;
     core.setFingerValue(label, v.x, v.y, { triggerRender: false });
   }
+}
+
+function buildAnimationTracksFromQuery(labels) {
+  const tracks = new Map();
+  for (const label of labels || []) {
+    const interval = readAnimationIntervalFromQuery(label);
+    if (interval) tracks.set(label, interval);
+  }
+  return tracks;
+}
+
+function applyAnimationStartValuesToCore(core, tracks) {
+  if (!core || !tracks) return;
+  for (const [label, interval] of tracks.entries()) {
+    if (!interval?.start) continue;
+    core.setFingerValue(label, interval.start.x, interval.start.y, { triggerRender: false });
+  }
+}
+
+function applyLatestAnimatedValuesToCore(core) {
+  if (!core || !animatedLabelSet.size) return;
+  for (const label of animatedLabelSet) {
+    const v = latestAnimatedValues.get(label);
+    if (!v) continue;
+    core.setFingerValue(label, v.x, v.y, { triggerRender: false });
+  }
+}
+
+function createAnimationController({ tracks, secondsPerSegment }) {
+  const state = {
+    tracks: new Map(tracks || []),
+    secondsPerSegment: Math.max(0.001, Number(secondsPerSegment) || DEFAULT_ANIMATION_SECONDS),
+    rafId: null,
+    playing: false,
+    paused: false,
+    pausedAtMs: 0,
+    perTrack: new Map(),
+  };
+
+  for (const [label, interval] of state.tracks.entries()) {
+    state.perTrack.set(label, { label, interval, baseStartMs: 0, initialized: false });
+  }
+
+  function lerpComplex(a, b, t) {
+    return { x: lerp(a.x, b.x, t), y: lerp(a.y, b.y, t) };
+  }
+
+  function stepTrack(track, nowMs) {
+    const durationMs = state.secondsPerSegment * 1000;
+    if (!track.initialized) {
+      track.baseStartMs = nowMs;
+      track.initialized = true;
+    }
+    const interval = track.interval;
+    const start = interval?.start;
+    const end = interval?.end;
+    if (!start || !end) return null;
+    const elapsed = nowMs - track.baseStartMs;
+    const t = durationMs > 0 ? elapsed / durationMs : 0;
+    const frac = t - Math.floor(t);
+    const clamped = Math.max(0, Math.min(1, frac));
+    return lerpComplex(start, end, clamped);
+  }
+
+  function frame(nowMs) {
+    if (!state.playing || state.paused) return;
+
+    for (const track of state.perTrack.values()) {
+      const value = stepTrack(track, nowMs);
+      if (!value) continue;
+      latestAnimatedValues.set(track.label, value);
+      topCore?.setFingerValue?.(track.label, value.x, value.y, { triggerRender: false });
+      thumbCore?.setFingerValue?.(track.label, value.x, value.y, { triggerRender: false });
+    }
+
+    // Only the top canvas needs continuous updates; thumbnails are updated on demand.
+    topCore?.render?.();
+    state.rafId = window.requestAnimationFrame(frame);
+  }
+
+  return {
+    start() {
+      if (state.playing && !state.paused) return;
+      state.playing = true;
+      state.paused = false;
+      state.rafId = window.requestAnimationFrame(frame);
+    },
+    pause() {
+      if (!state.playing || state.paused) return;
+      state.paused = true;
+      state.pausedAtMs = performance.now();
+      if (state.rafId != null) {
+        window.cancelAnimationFrame(state.rafId);
+        state.rafId = null;
+      }
+    },
+    resume() {
+      if (!state.playing || !state.paused) return;
+      const now = performance.now();
+      const delta = now - (state.pausedAtMs || now);
+      for (const track of state.perTrack.values()) {
+        if (track.initialized) {
+          track.baseStartMs += delta;
+        }
+      }
+      state.paused = false;
+      state.rafId = window.requestAnimationFrame(frame);
+    },
+    stop() {
+      state.playing = false;
+      state.paused = false;
+      if (state.rafId != null) {
+        window.cancelAnimationFrame(state.rafId);
+        state.rafId = null;
+      }
+    },
+    isPlaying() {
+      return state.playing && !state.paused;
+    },
+  };
 }
 
 function setUiDisabled(disabled) {
@@ -642,6 +802,10 @@ async function animateTopToFingers(targetFingers, { durationMs } = {}) {
   const token = ++pendingTransitionToken;
   isTransitioning = true;
   pushUiFreeze();
+  const shouldResumeAnimations = Boolean(animationController?.isPlaying?.());
+  if (shouldResumeAnimations) {
+    animationController.pause();
+  }
 
   try {
     const from = readFingersFromCore(topCore, activeLabels);
@@ -667,6 +831,7 @@ async function animateTopToFingers(targetFingers, { durationMs } = {}) {
       const e = easeInOutCubic(t);
 
       for (const label of activeLabels) {
+        if (animatedLabelSet.has(label)) continue;
         const a = from[label] || { x: 0, y: 0 };
         const b = to[label] || a;
         const x = lerp(a.x, b.x, e);
@@ -679,7 +844,8 @@ async function animateTopToFingers(targetFingers, { durationMs } = {}) {
     }
 
     // Snap to exact target at the end (avoid drift).
-    applyFingersToCore(topCore, to);
+    applyFingersToCore(topCore, to, { ignoreLabels: animatedLabelSet });
+    applyLatestAnimatedValuesToCore(topCore);
     topCore.render();
     await waitForNextFrame();
 
@@ -687,6 +853,9 @@ async function animateTopToFingers(targetFingers, { durationMs } = {}) {
   } finally {
     isTransitioning = false;
     popUiFreeze();
+    if (shouldResumeAnimations) {
+      animationController.resume();
+    }
   }
 }
 
@@ -710,7 +879,8 @@ function updateUrlForBaseFingers(baseFingers) {
 
 async function renderTop(snapshot) {
   if (!topCore || !snapshot) return;
-  applyFingersToCore(topCore, snapshot.baseFingers);
+  applyFingersToCore(topCore, snapshot.baseFingers, { ignoreLabels: animatedLabelSet });
+  applyLatestAnimatedValuesToCore(topCore);
   topCore.render();
   await waitForNextFrame();
 }
@@ -756,7 +926,8 @@ async function renderThumbs(snapshot) {
           // ignore
         }
 
-        applyFingersToCore(thumbCore, candidate.fingers);
+        applyFingersToCore(thumbCore, candidate.fingers, { ignoreLabels: animatedLabelSet });
+        applyLatestAnimatedValuesToCore(thumbCore);
         thumbCore.renderToPixelSize(targetW, targetH);
         try {
           thumbCore.gl?.finish?.();
@@ -1126,6 +1297,7 @@ async function bootstrap() {
 
   // Seed finger values from query for parse-time desugaring (e.g. $$ counts).
   const params = new URLSearchParams(window.location.search);
+  animationSeconds = parseSecondsFromQuery(params.get(ANIMATION_TIME_PARAM)) ?? DEFAULT_ANIMATION_SECONDS;
   solosPresent = params.has(SOLOS_PARAM);
   soloLabelSet = solosPresent ? parseSolosParam(params.get(SOLOS_PARAM)) : new Set();
   const seededFingerValues = {};
@@ -1191,6 +1363,18 @@ async function bootstrap() {
     }
   }
 
+  // If any parameters are animated (as configured in index.html), apply their start values now.
+  const initialTracks = buildAnimationTracksFromQuery(allUsedLabels);
+  animatedLabelSet = new Set(Array.from(initialTracks.keys()));
+  if (initialTracks.size) {
+    applyAnimationStartValuesToCore(topCore, initialTracks);
+    for (const [label, interval] of initialTracks.entries()) {
+      if (interval?.start) {
+        latestAnimatedValues.set(label, { x: interval.start.x, y: interval.start.y });
+      }
+    }
+  }
+
   // Ensure layout is ready so view extents are correct.
   await waitForNextFrame();
   topCore.render();
@@ -1221,6 +1405,9 @@ async function bootstrap() {
   document.body.appendChild(thumbWebglCanvas);
   thumbCore = new ReflexCore(thumbWebglCanvas, activeAst, { autoRender: false, installEventListeners: false });
   thumbCore.setActiveFingerConfig(activeFingerConfig);
+  if (initialTracks.size) {
+    applyAnimationStartValuesToCore(thumbCore, initialTracks);
+  }
 
   const baseKey = snapshotKey({ formulaSource: activeFormulaSource, fingers: clampedBase });
   const visitedTopKeys = new Set([baseKey]);
@@ -1242,6 +1429,13 @@ async function bootstrap() {
 
   await updateUrlForBaseFingers(clampedBase);
   await renderAll();
+
+  // Start URL-driven animations after first paint.
+  if (initialTracks.size) {
+    animationController?.stop?.();
+    animationController = createAnimationController({ tracks: initialTracks, secondsPerSegment: animationSeconds });
+    animationController.start();
+  }
 }
 
 bootstrap().catch((err) => {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=26.0';
+  const SW_URL = './service-worker.js?sw=27.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1025,7 +1025,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v26</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v27</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -57,7 +57,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 26;
+const APP_VERSION = 27;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -3659,7 +3659,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=26.0';
+  const SW_URL = './service-worker.js?sw=27.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '26.0';
+const CACHE_MINOR = '27.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Enable URL-driven parameter animations in `explore.html` to synchronize animation playback with `index.html`.

The `explore.html` interface now parses and plays animated parameters (e.g., `F1A=start..end` and `t=5s`) from the URL, ensuring that if a shared link includes animated values, the explore page will render them dynamically. This aligns its behavior with `index.html`, which already supports this functionality, as a step towards merging the two interfaces. Animations are paused during "fly-to" transitions to prevent conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-690f0621-50cb-4e6f-9cf1-912968b952aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-690f0621-50cb-4e6f-9cf1-912968b952aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

