### PR TITLE
Animation parameter interaction

### DIFF
--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -132,10 +132,17 @@ function sortFingerLabels(labels) {
     .sort((a, b) => {
       const fa = fingerFamily(a);
       const fb = fingerFamily(b);
-      if (fa !== fb) {
-        // Keep fixed/dynamic ahead of workspace.
-        if (fa === 'w') return 1;
-        if (fb === 'w') return -1;
+      // Group by family: fixed (F*) first, then dynamic (D*), then workspace (W*).
+      const rank = (family) => {
+        if (family === 'fixed') return 0;
+        if (family === 'dynamic') return 1;
+        if (family === 'w') return 2;
+        return 3;
+      };
+      const ra = rank(fa);
+      const rb = rank(fb);
+      if (ra !== rb) {
+        return ra - rb;
       }
       return fingerIndex(a) - fingerIndex(b);
     });
@@ -650,7 +657,6 @@ function buildInlineFingerValueEditor(label) {
       Boolean(globalEffectiveTrackLabelSet?.has?.(label));
     const previewPlayingThis =
       Boolean(animated) &&
-      Boolean(previewController?.isPlaying?.()) &&
       Boolean(previewLabelSet && previewLabelSet.has(label));
     const playing = globalPlayingThis || previewPlayingThis;
     playBtn.textContent = playing ? '⏸' : '▶';


### PR DESCRIPTION
Enables immediate animation playback for animatable parameters and groups parameter constants by category.

The inline editor for animatable parameters no longer collapses prematurely on `focusout` events (e.g., when tapping the play button on mobile), allowing the play action to register immediately. Additionally, the parameter list now sorts 'F' (fixed) parameters before 'D' (dynamic) and 'W' (workspace) parameters, maintaining numerical order within each group.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a22ccf3-8bbf-4218-bfdd-6cc861dbafe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a22ccf3-8bbf-4218-bfdd-6cc861dbafe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

