### PR TITLE
Atan2 support reflex4you

### DIFF
--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -189,7 +189,8 @@ Then apply your preferred yaw/pitch/roll convention. Here is one **concrete exam
 
 Notes:
 
-- Reflex supports `atan2(y, x)` (like `Math.atan2`): it returns a **real** angle in radians (using the **real parts** of `y` and `x`).
+- Reflex supports `arg(z)` (and synonym `argument(z)`): it returns the **phase** of `z` (i.e. `atan2(im(z), re(z))`) as a **real** angle in radians.
+- `arg(z, k)` forwards `k` to `ln(z, k)` so you can control the branch cut (it is computed as `imag(ln(z, k))`).
 - Clamping to `[-1, 1]` is written explicitly with nested `if(...)`.
 
 ```text
@@ -204,11 +205,11 @@ set pitchX = asin(tPitchClamped) in
 
 set yawNum = 2*(qw*qy + qx*qz) in
 set yawDen = 1 - 2*(qx*qx + qy*qy) in
-set yawY = atan2(yawNum, yawDen) in
+set yawY = arg(yawDen + i*yawNum) in
 
 set rollNum = 2*(qw*qz + qx*qy) in
 set rollDen = 1 - 2*(qx*qx + qz*qz) in
-set rollZ = atan2(rollNum, rollDen) in
+set rollZ = arg(rollDen + i*rollNum) in
 
 yawY + i*pitchX
 ```
@@ -233,7 +234,7 @@ The input accepts succinct expressions with complex arithmetic, composition, and
 - **3D rotations (SU(2))**: `QA`, `QB` (device), `RA`, `RB` (trackball).
 - **Literals:** `1.25`, `-3.5`, `2+3i`, `0,1`, `i`, `-i`, `j` (for `-½ + √3/2 i`).
 - **Operators:** `+`, `-`, `*`, `/`, power (`^` with integer exponents), composition (`o(f, g)` or `f $ g`), repeated composition (`oo(f, n)` or `f $$ n`).
-- **Functions:** `exp`, `sin`, `cos`, `tan`, `atan`/`arctan`, `atan2`, `asin`/`arcsin`, `acos`/`arccos`, `ln`, `sqrt`, `abs`/`modulus`, `abs2`, `floor`, `conj`, `heav`, `isnan`, `ifnan`/`iferror`. `sqrt(z, k)` desugars to `exp(0.5 * ln(z, k))`, so the optional second argument shifts the log branch; `heav(x)` evaluates to `1` when `x > 0` and `0` otherwise.
+- **Functions:** `exp`, `sin`, `cos`, `tan`, `atan`/`arctan`, `arg`/`argument`, `asin`/`arcsin`, `acos`/`arccos`, `ln`, `sqrt`, `abs`/`modulus`, `abs2`, `floor`, `conj`, `heav`, `isnan`, `ifnan`/`iferror`. `sqrt(z, k)` desugars to `exp(0.5 * ln(z, k))`, so the optional second argument shifts the log branch; `heav(x)` evaluates to `1` when `x > 0` and `0` otherwise.
 - **Conditionals:** comparisons (`<`, `<=`, `>`, `>=`, `==`), logical ops (`&&`, `||`), and `if(cond, then, else)`.
 - **Bindings:** `set name = value in body` introduces reusable values (serialized with the formula when shared).
 

--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -189,13 +189,10 @@ Then apply your preferred yaw/pitch/roll convention. Here is one **concrete exam
 
 Notes:
 
-- Reflex currently has `atan(...)` but not `atan2(y, x)`. The snippet below shows an `atan2`-style pattern using `if(...)`.
+- Reflex supports `atan2(y, x)` (like `Math.atan2`): it returns a **real** angle in radians (using the **real parts** of `y` and `x`).
 - Clamping to `[-1, 1]` is written explicitly with nested `if(...)`.
 
 ```text
-set pi = 3.141592653589793 in
-set eps = 1e-9 in
-
 set qw = A.x in
 set qx = B.x in
 set qy = B.y in
@@ -207,21 +204,11 @@ set pitchX = asin(tPitchClamped) in
 
 set yawNum = 2*(qw*qy + qx*qz) in
 set yawDen = 1 - 2*(qx*qx + qy*qy) in
-set yawY =
-  if(abs(yawDen) < eps,
-    if(yawNum > 0, pi/2, if(yawNum < 0, -pi/2, 0)),
-    set a = atan(yawNum / yawDen) in
-    if(yawDen > 0, a, if(yawNum >= 0, a + pi, a - pi))
-  ) in
+set yawY = atan2(yawNum, yawDen) in
 
 set rollNum = 2*(qw*qz + qx*qy) in
 set rollDen = 1 - 2*(qx*qx + qz*qz) in
-set rollZ =
-  if(abs(rollDen) < eps,
-    if(rollNum > 0, pi/2, if(rollNum < 0, -pi/2, 0)),
-    set a = atan(rollNum / rollDen) in
-    if(rollDen > 0, a, if(rollNum >= 0, a + pi, a - pi))
-  ) in
+set rollZ = atan2(rollNum, rollDen) in
 
 yawY + i*pitchX
 ```
@@ -246,7 +233,7 @@ The input accepts succinct expressions with complex arithmetic, composition, and
 - **3D rotations (SU(2))**: `QA`, `QB` (device), `RA`, `RB` (trackball).
 - **Literals:** `1.25`, `-3.5`, `2+3i`, `0,1`, `i`, `-i`, `j` (for `-½ + √3/2 i`).
 - **Operators:** `+`, `-`, `*`, `/`, power (`^` with integer exponents), composition (`o(f, g)` or `f $ g`), repeated composition (`oo(f, n)` or `f $$ n`).
-- **Functions:** `exp`, `sin`, `cos`, `tan`, `atan`, `ln`, `sqrt`, `abs`/`modulus`, `floor`, `conj`, `heav`. `sqrt(z, k)` desugars to `exp(0.5 * ln(z, k))`, so the optional second argument shifts the log branch; `heav(x)` evaluates to `1` when `x > 0` and `0` otherwise.
+- **Functions:** `exp`, `sin`, `cos`, `tan`, `atan`/`arctan`, `atan2`, `asin`/`arcsin`, `acos`/`arccos`, `ln`, `sqrt`, `abs`/`modulus`, `abs2`, `floor`, `conj`, `heav`, `isnan`, `ifnan`/`iferror`. `sqrt(z, k)` desugars to `exp(0.5 * ln(z, k))`, so the optional second argument shifts the log branch; `heav(x)` evaluates to `1` when `x > 0` and `0` otherwise.
 - **Conditionals:** comparisons (`<`, `<=`, `>`, `>=`, `==`), logical ops (`&&`, `||`), and `if(cond, then, else)`.
 - **Bindings:** `set name = value in body` introduces reusable values (serialized with the formula when shared).
 

--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -438,6 +438,8 @@ const RESERVED_BINDING_NAMES = new Set([
   'o',
   'x',
   'y',
+  're',
+  'im',
   'real',
   'imag',
   'z',
@@ -503,6 +505,12 @@ const primitiveParser = Choice([
     attachIdentifierMeta(withSyntax(withSpan(VarX(), result.span), token.text), token),
   ),
   keywordLiteral('y', { ctor: 'VarY' }).Map((token, result) =>
+    attachIdentifierMeta(withSyntax(withSpan(VarY(), result.span), token.text), token),
+  ),
+  keywordLiteral('re', { ctor: 'VarRe' }).Map((token, result) =>
+    attachIdentifierMeta(withSyntax(withSpan(VarX(), result.span), token.text), token),
+  ),
+  keywordLiteral('im', { ctor: 'VarIm' }).Map((token, result) =>
     attachIdentifierMeta(withSyntax(withSpan(VarY(), result.span), token.text), token),
   ),
   keywordLiteral('real', { ctor: 'VarReal' }).Map((token, result) =>

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -524,6 +524,30 @@ test('tracks syntax labels for axis primitives', () => {
   assert.equal(imagResult.ok, true);
   assert.equal(imagResult.value.kind, 'VarY');
   assert.equal(imagResult.value.syntaxLabel, 'imag');
+
+  const reResult = parseFormulaInput('re');
+  assert.equal(reResult.ok, true);
+  assert.equal(reResult.value.kind, 'VarX');
+  assert.equal(reResult.value.syntaxLabel, 're');
+
+  const imResult = parseFormulaInput('im');
+  assert.equal(imResult.ok, true);
+  assert.equal(imResult.value.kind, 'VarY');
+  assert.equal(imResult.value.syntaxLabel, 'im');
+});
+
+test('re(z) and im(z) behave like real(z) and imag(z)', () => {
+  const reCall = parseFormulaInput('re(z)');
+  assert.equal(reCall.ok, true);
+  assert.equal(reCall.value.kind, 'Compose');
+  assert.equal(reCall.value.f.kind, 'VarX');
+  assert.equal(reCall.value.g.kind, 'Var');
+
+  const imCall = parseFormulaInput('im(z)');
+  assert.equal(imCall.ok, true);
+  assert.equal(imCall.value.kind, 'Compose');
+  assert.equal(imCall.value.f.kind, 'VarY');
+  assert.equal(imCall.value.g.kind, 'Var');
 });
 
 test('explicit composition accepts built-in literals', () => {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -131,12 +131,26 @@ test('parses tan and atan calls', () => {
   assert.equal(result.value.value.kind, 'Atan');
 });
 
-test('parses atan2(y, x) calls', () => {
-  const result = parseFormulaInput('atan2(1, -1)');
+test('parses arg(z) and argument(z) calls', () => {
+  const argResult = parseFormulaInput('arg(z)');
+  assert.equal(argResult.ok, true);
+  assert.equal(argResult.value.kind, 'Arg');
+  assert.equal(argResult.value.value.kind, 'Var');
+  assert.equal(argResult.value.branch, null);
+
+  const argumentResult = parseFormulaInput('argument(z)');
+  assert.equal(argumentResult.ok, true);
+  assert.equal(argumentResult.value.kind, 'Arg');
+  assert.equal(argumentResult.value.value.kind, 'Var');
+  assert.equal(argumentResult.value.branch, null);
+});
+
+test('arg(z, k) forwards the branch argument (like ln)', () => {
+  const result = parseFormulaInput('arg(z, x + 1)');
   assert.equal(result.ok, true);
-  assert.equal(result.value.kind, 'Atan2');
-  assert.equal(result.value.y.kind, 'Const');
-  assert.equal(result.value.x.kind, 'Const');
+  assert.equal(result.value.kind, 'Arg');
+  assert.equal(result.value.value.kind, 'Var');
+  assert.equal(result.value.branch.kind, 'Add');
 });
 
 test('parses arc trig aliases', () => {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -131,6 +131,14 @@ test('parses tan and atan calls', () => {
   assert.equal(result.value.value.kind, 'Atan');
 });
 
+test('parses atan2(y, x) calls', () => {
+  const result = parseFormulaInput('atan2(1, -1)');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Atan2');
+  assert.equal(result.value.y.kind, 'Const');
+  assert.equal(result.value.x.kind, 'Const');
+});
+
 test('parses arc trig aliases', () => {
   const asinResult = parseFormulaInput('asin(z)');
   assert.equal(asinResult.ok, true);

--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -38,11 +38,13 @@ export function childEntries(node) {
     case 'Conjugate':
     case 'IsNaN':
       return [['value', node.value]];
-    case 'Atan2':
-      return [
-        ['y', node.y],
-        ['x', node.x],
-      ];
+    case 'Arg': {
+      const entries = [['value', node.value]];
+      if (node.branch) {
+        entries.push(['branch', node.branch]);
+      }
+      return entries;
+    }
     case 'Ln': {
       const entries = [['value', node.value]];
       if (node.branch) {

--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -38,6 +38,11 @@ export function childEntries(node) {
     case 'Conjugate':
     case 'IsNaN':
       return [['value', node.value]];
+    case 'Atan2':
+      return [
+        ['y', node.y],
+        ['x', node.x],
+      ];
     case 'Ln': {
       const entries = [['value', node.value]];
       if (node.branch) {

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -20,7 +20,7 @@ import {
   Cos,
   Tan,
   Atan,
-  Atan2,
+  Arg,
   Asin,
   Acos,
   Ln,
@@ -225,11 +225,14 @@ test('tan and atan nodes emit their helpers', () => {
   assert.match(fragment, /c_atan/);
 });
 
-test('atan2 nodes emit GLSL atan(y, x) on real parts', () => {
-  const ast = Atan2(VarY(), VarX());
-  const fragment = buildFragmentSourceFromAST(ast);
-  assert.match(fragment, /atan\(yv\.x, xv\.x\)/);
-  assert.match(fragment, /vec2\(angle, 0\.0\)/);
+test('Arg nodes emit imag(ln) and support branch shifts', () => {
+  const fragment = buildFragmentSourceFromAST(Arg(VarZ()));
+  assert.match(fragment, /vec2 lv = c_ln\(v\);/);
+  assert.match(fragment, /return vec2\(lv\.y, 0\.0\);/);
+
+  const fragmentWithBranch = buildFragmentSourceFromAST(Arg(VarZ(), VarX()));
+  assert.match(fragmentWithBranch, /c_ln_branch\(v, branchShift\.x\)/);
+  assert.match(fragmentWithBranch, /return vec2\(lv\.y, 0\.0\);/);
 });
 
 test('asin and acos nodes emit their helpers', () => {

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -20,6 +20,7 @@ import {
   Cos,
   Tan,
   Atan,
+  Atan2,
   Asin,
   Acos,
   Ln,
@@ -222,6 +223,13 @@ test('tan and atan nodes emit their helpers', () => {
   const fragment = buildFragmentSourceFromAST(ast);
   assert.match(fragment, /c_tan/);
   assert.match(fragment, /c_atan/);
+});
+
+test('atan2 nodes emit GLSL atan(y, x) on real parts', () => {
+  const ast = Atan2(VarY(), VarX());
+  const fragment = buildFragmentSourceFromAST(ast);
+  assert.match(fragment, /atan\(yv\.x, xv\.x\)/);
+  assert.match(fragment, /vec2\(angle, 0\.0\)/);
 });
 
 test('asin and acos nodes emit their helpers', () => {

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1307,7 +1307,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=28.16';
+    const SW_URL = './service-worker.js?sw=29.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1307,7 +1307,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=28.14';
+    const SW_URL = './service-worker.js?sw=28.15';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1307,7 +1307,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=28.15';
+    const SW_URL = './service-worker.js?sw=28.16';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=28.14';
+  const SW_URL = './service-worker.js?sw=28.15';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=28.16';
+  const SW_URL = './service-worker.js?sw=29.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=28.15';
+  const SW_URL = './service-worker.js?sw=28.16';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -302,8 +302,22 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
       return `${identifierHighlights(node).length ? operatorNameWithMetadata('tan', identifierHighlights(node)) : '\\tan'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Atan':
       return `${identifierHighlights(node).length ? operatorNameWithMetadata('atan', identifierHighlights(node)) : '\\arctan'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
-    case 'Atan2':
-      return functionCallLatex('atan2', [node.y, node.x], options, identifierHighlights(node));
+    case 'Arg': {
+      const value = nodeToLatex(node.value, 0, options);
+      const label = String(node.syntaxLabel || 'arg');
+      const meta = identifierHighlights(node);
+      const op =
+        meta.length
+          ? operatorNameWithMetadata(label, meta)
+          : label === 'arg'
+            ? '\\arg'
+            : `\\operatorname{${escapeLatexIdentifier(label)}}`;
+      if (node.branch) {
+        const branch = nodeToLatex(node.branch, 0, options);
+        return `${op}_{${branch}}\\left(${value}\\right)`;
+      }
+      return `${op}\\left(${value}\\right)`;
+    }
     case 'Asin':
       return `${identifierHighlights(node).length ? operatorNameWithMetadata('asin', identifierHighlights(node)) : '\\arcsin'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Acos':

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -302,6 +302,8 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
       return `${identifierHighlights(node).length ? operatorNameWithMetadata('tan', identifierHighlights(node)) : '\\tan'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Atan':
       return `${identifierHighlights(node).length ? operatorNameWithMetadata('atan', identifierHighlights(node)) : '\\arctan'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
+    case 'Atan2':
+      return functionCallLatex('atan2', [node.y, node.x], options, identifierHighlights(node));
     case 'Asin':
       return `${identifierHighlights(node).length ? operatorNameWithMetadata('asin', identifierHighlights(node)) : '\\arcsin'}\\left(${nodeToLatex(node.value, 0, options)}\\right)`;
     case 'Acos':

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1025,7 +1025,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v28</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v29</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -4011,7 +4011,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=28.15';
+  const SW_URL = './service-worker.js?sw=28.16';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -4011,7 +4011,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=28.14';
+  const SW_URL = './service-worker.js?sw=28.15';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -57,7 +57,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 28;
+const APP_VERSION = 29;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4011,7 +4011,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=28.16';
+  const SW_URL = './service-worker.js?sw=29.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '28.16';
+const CACHE_MINOR = '29.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '28.15';
+const CACHE_MINOR = '28.16';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '28.14';
+const CACHE_MINOR = '28.15';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Add `atan2(y, x)` support to Reflex4You to provide a standard two-argument arctangent function and update documentation.

The previous approach required a verbose `if(...)` statement to emulate `atan2`, which is now replaced by a direct function call, simplifying complex angle calculations. This also bumps the app's minor version.

---
<a href="https://cursor.com/background-agent?bcId=bc-94066c85-1f54-47d8-9e5e-d1d3bef3edf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94066c85-1f54-47d8-9e5e-d1d3bef3edf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

