### PR TITLE
PWA screen timeout disable

### DIFF
--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1307,7 +1307,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=31.1';
+    const SW_URL = './service-worker.js?sw=32.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/explore.html
+++ b/apps/reflex4you/explore.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Reflex4You explore mode – thumbnail maze for parameters." />
   <link rel="manifest" href="./manifest.json" />
   <script src="./orientation-lock.js"></script>
+  <script src="./wake-lock.js"></script>
   <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png" />
   <link rel="icon" type="image/png" sizes="512x512" href="./icon-512.png" />
   <link rel="apple-touch-icon" href="./icon-192.png" />

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=31.1';
+  const SW_URL = './service-worker.js?sw=32.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula.html
+++ b/apps/reflex4you/formula.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Reflex4You formula view." />
   <link rel="manifest" href="./manifest.json" />
   <script src="./orientation-lock.js"></script>
+  <script src="./wake-lock.js"></script>
   <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png" />
   <link rel="icon" type="image/png" sizes="512x512" href="./icon-512.png" />
   <link rel="apple-touch-icon" href="./icon-192.png" />

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -26,6 +26,7 @@
   </script>
   <link rel="manifest" href="./manifest.json" />
   <script src="./orientation-lock.js"></script>
+  <script src="./wake-lock.js"></script>
   <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png" />
   <link rel="icon" type="image/png" sizes="512x512" href="./icon-512.png" />
   <link rel="apple-touch-icon" href="./icon-192.png" />
@@ -1025,7 +1026,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v31</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v32</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -57,7 +57,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 31;
+const APP_VERSION = 32;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4011,7 +4011,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=31.1';
+  const SW_URL = './service-worker.js?sw=32.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/package.json
+++ b/apps/reflex4you/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflex4you",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Local tooling for the Reflex4You app",
   "scripts": {
     "test": "playwright test",

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '31.1';
+const CACHE_MINOR = '32.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope
@@ -27,6 +27,7 @@ const PRECACHE_URLS = [
   './explore.html',
   './manifest.json',
   './orientation-lock.js',
+  './wake-lock.js',
   './icon-192.png',
   './icon-512.png',
   './Screenshot_20251213-082055.png',

--- a/apps/reflex4you/wake-lock.js
+++ b/apps/reflex4you/wake-lock.js
@@ -1,0 +1,89 @@
+// apps/reflex4you/wake-lock.js
+//
+// Best-effort "keep screen awake" for installed PWAs / supported browsers.
+// Uses the Screen Wake Lock API when available.
+//
+// Notes:
+// - Many platforms do not support wake locks (notably iOS Safari).
+// - Some browsers require a user activation; we retry on first interactions.
+// - Wake locks are released when the page is hidden; we re-acquire on resume.
+
+(function () {
+  /** @type {WakeLockSentinel | null} */
+  let sentinel = null;
+
+  function supported() {
+    try {
+      return typeof navigator !== 'undefined' && navigator.wakeLock && typeof navigator.wakeLock.request === 'function';
+    } catch (_) {
+      return false;
+    }
+  }
+
+  async function release() {
+    try {
+      if (sentinel && typeof sentinel.release === 'function') {
+        await sentinel.release();
+      }
+    } catch (_) {
+      // ignore
+    } finally {
+      sentinel = null;
+    }
+  }
+
+  async function request() {
+    try {
+      if (!supported()) return;
+      if (typeof document !== 'undefined' && document.hidden) return;
+      if (sentinel) return;
+
+      sentinel = await navigator.wakeLock.request('screen');
+      if (sentinel && typeof sentinel.addEventListener === 'function') {
+        sentinel.addEventListener('release', () => {
+          sentinel = null;
+        });
+      }
+    } catch (_) {
+      // Common failure modes:
+      // - NotAllowedError (no user activation / permission policy)
+      // - NotSupportedError (platform)
+      // We'll retry on the next lifecycle/user event.
+      sentinel = null;
+    }
+  }
+
+  // Try ASAP (works in many Chromium PWAs).
+  request();
+
+  // Lifecycle: reacquire on resume; release when backgrounded.
+  try {
+    document.addEventListener(
+      'visibilitychange',
+      () => {
+        if (document.hidden) release();
+        else request();
+      },
+      { passive: true },
+    );
+  } catch (_) {
+    // ignore
+  }
+
+  try {
+    window.addEventListener('pageshow', () => request(), { passive: true });
+    window.addEventListener('pagehide', () => release(), { passive: true });
+  } catch (_) {
+    // ignore
+  }
+
+  // Many browsers require a user activation; retry on first interactions.
+  try {
+    const onActivate = () => request();
+    document.addEventListener('pointerdown', onActivate, { passive: true, capture: true });
+    document.addEventListener('keydown', onActivate, { passive: true, capture: true });
+  } catch (_) {
+    // ignore
+  }
+})();
+


### PR DESCRIPTION
Add screen wake lock to the Reflex4You PWA to prevent the screen from turning off, and bump the major version.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee2ec119-d85b-44cb-b439-3548ff2062c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee2ec119-d85b-44cb-b439-3548ff2062c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

