### PR TITLE
Function node value capture

### DIFF
--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -118,6 +118,18 @@ test('repeat composition inside let bindings compiles (let fn = z $$ 2 in fn)', 
   assert.match(fragment, /vec2 let_fn_0\(vec2 z\)\s*\{\s*return z;\s*\}/);
 });
 
+test('let alias preserves captured set bindings (set d = 1 in let f = z + d in let g = f in g)', () => {
+  const parsed = parseFormulaInput('set d = 1 in let f = z + d in let g = f in g');
+  assert.equal(parsed.ok, true);
+  let fragment = '';
+  assert.doesNotThrow(() => {
+    fragment = buildFragmentSourceFromAST(parsed.value);
+  });
+  // At least one let-bound function should capture a set binding.
+  assert.match(fragment, /cap_s_/);
+  assert.doesNotMatch(fragment, /undefined/);
+});
+
 test('buildFragmentSourceFromAST does not silently drop legacy RepeatComposePlaceholder nodes', () => {
   // This node kind should normally be resolved during parsing, but shader generation
   // must not compile it as just the base when the count is a literal.


### PR DESCRIPTION
Fix compilation error when aliasing let-bound functions by ensuring captured `set` values are propagated.

When `let g = f` where `f` captures a `set` value (e.g., `d`), `g`'s capture list was computed as empty. During codegen, when `g` called `f`, `d` was not available, leading to a "Missing captured set" error. This PR updates capture collection to transitively pull in the captures of the aliased function.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bcc4698-7f61-459a-ac55-5370fe83e8d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3bcc4698-7f61-459a-ac55-5370fe83e8d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

