### PR TITLE
Reflex4you v identifier purpose

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -850,29 +850,19 @@ test('parses conj() calls as conjugate nodes', () => {
   assert.equal(node.value.kind, 'Var');
 });
 
-test('comp(...) expands iterative compositions', () => {
-  const result = parseFormulaInput('comp(v^2+z, v, 0, 2)');
+test('v is available as a normal identifier (bindable via set)', () => {
+  const result = parseFormulaInput('set v = 1 in v + 2');
   assert.equal(result.ok, true);
   const ast = result.value;
-  assert.equal(ast.kind, 'Add');
-  assert.equal(ast.left.kind, 'Pow');
-  assert.equal(ast.left.base.kind, 'Add');
-  assert.equal(ast.left.exponent, 2);
-  assert.equal(ast.left.base.right.kind, 'Var');
-  assert.equal(ast.right.kind, 'Var');
+  assert.equal(ast.kind, 'SetBinding');
+  assert.equal(ast.name, 'v');
+  assert.equal(ast.body.kind, 'Add');
 });
 
-test('comp with zero iterations returns the seed expression', () => {
-  const result = parseFormulaInput('comp(v+1, v, z, 0)');
-  assert.equal(result.ok, true);
-  const ast = result.value;
-  assert.equal(ast.kind, 'Var');
-});
-
-test('standalone iteration variables are rejected', () => {
+test('unbound v behaves like any unknown identifier', () => {
   const result = parseFormulaInput('v + 1');
   assert.equal(result.ok, false);
-  assert.match(result.message, /comp/i);
+  assert.match(result.message, /Unknown variable "v"/);
 });
 
 test('underscore-marked identifiers record highlight metadata and render as Huge letters (LEON)', () => {
@@ -887,12 +877,4 @@ test('underscore-marked identifiers record highlight metadata and render as Huge
   assert.ok(latex.indexOf('{\\Huge L}') < latex.indexOf('{\\Huge E}'));
   assert.ok(latex.indexOf('{\\Huge E}') < latex.indexOf('{\\Huge O}'));
   assert.ok(latex.indexOf('{\\Huge O}') < latex.indexOf('{\\Huge N}'));
-});
-
-test('comp(...) can clone floor(...) nodes (cloneAst supports Floor)', () => {
-  assert.doesNotThrow(() => {
-    const result = parseFormulaInput('comp(v+1, v, floor(z), 0)');
-    assert.equal(result.ok, true);
-    assert.equal(result.value.kind, 'Floor');
-  });
 });

--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -119,7 +119,6 @@ export function childEntries(node) {
       ];
     case 'SetRef':
     case 'Identifier':
-    case 'PlaceholderVar':
     case 'ParamRef':
     case 'Const':
     case 'Var':

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1307,7 +1307,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=32.0';
+    const SW_URL = './service-worker.js?sw=33.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=32.0';
+  const SW_URL = './service-worker.js?sw=33.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1026,7 +1026,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v32</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v33</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -57,7 +57,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 32;
+const APP_VERSION = 33;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4011,7 +4011,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=32.0';
+  const SW_URL = './service-worker.js?sw=33.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '32.0';
+const CACHE_MINOR = '33.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Remove `comp(...)` function, make `v` a normal identifier, and bump the major version of Reflex4You.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8815f1f-af2f-4d3b-b52b-6ffad18e6efc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8815f1f-af2f-4d3b-b52b-6ffad18e6efc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

