### PR TITLE
Repeat expression language extension

### DIFF
--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -236,7 +236,7 @@ The input accepts succinct expressions with complex arithmetic, composition, and
 - **Operators:** `+`, `-`, `*`, `/`, power (`^` with integer exponents), composition (`o(f, g)` or `f $ g`), repeated composition (`oo(f, n)` or `f $$ n`).
 - **Loops:** `repeat n from a1, a2, ..., ak by f1, f2, ..., fk` iterates a **k-register state** for `n` steps and returns the final `r1`.
   - `n` must be a **compile-time integer** (e.g. `10`, `floor(3.9)`); if `n <= 0` it performs zero iterations and returns `a1`.
-  - Each `fj` must be a **user-defined** `let` function with exactly `k+1` parameters: `fj(i, r1, ..., rk)`.
+  - Each `fj` must be a **user-defined** `let` function with exactly `k+1` parameters: `fj(k, r1, ..., rk)`.
   - Dot composition is equivalent: `f $ expr` is the same as `expr.f` (so `a.b` means `b(a(z))`).
 - **Functions:** `exp`, `sin`, `cos`, `tan`, `atan`/`arctan`, `arg`/`argument`, `asin`/`arcsin`, `acos`/`arccos`, `ln`, `sqrt`, `abs`/`modulus`, `abs2`, `floor`, `conj`, `heav`, `isnan`, `ifnan`/`iferror`. `sqrt(z, k)` desugars to `exp(0.5 * ln(z, k))`, so the optional second argument shifts the log branch; `heav(x)` evaluates to `1` when `x > 0` and `0` otherwise.
 - **Conditionals:** comparisons (`<`, `<=`, `>`, `>=`, `==`), logical ops (`&&`, `||`), and `if(cond, then, else)`.
@@ -288,27 +288,27 @@ All examples below return a **single complex value** (no tuples/arrays are intro
 
 ```text
 # Sum of integers: 0 + 1 + ... + 9 = 45
-let step(i, s) = s + i in
+let step(k, s) = s + k in
 repeat 10 from 0 by step
 
 # Sum of squares: 0^2 + 1^2 + ... + 9^2 = 285
-let step(i, s) = s + i*i in
+let step(k, s) = s + k*k in
 repeat 10 from 0 by step
 
 # Alternate sum of cubes: Σ (-1)^i * i^3 for i=0..9
-let fs(i, s, sign) = s + sign*(i^3) in
-let fsign(i, s, sign) = -sign in
+let fs(k, s, sign) = s + sign*(k^3) in
+let fsign(k, s, sign) = -sign in
 repeat 10 from 0, 1 by fs, fsign
 
 # Sum of fourth powers: Σ i^4 for i=0..9
-let step(i, s) = s + i^4 in
+let step(k, s) = s + k^4 in
 repeat 10 from 0 by step
 
 # Truncated exp series (n terms): Σ z^i / i! for i=0..n-1
 # Registers: (sum, term, zConst). Keep zConst unchanged across iterations.
-let fsum(i, sum, term, zc) = sum + term in
-let fterm(i, sum, term, zc) = term * zc / (i + 1) in
-let fz(i, sum, term, zc) = zc in
+let fsum(k, sum, term, zc) = sum + term in
+let fterm(k, sum, term, zc) = term * zc / (k + 1) in
+let fz(k, sum, term, zc) = zc in
 repeat 12 from 0, 1, z by fsum, fterm, fz
 ```
 

--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -234,6 +234,9 @@ The input accepts succinct expressions with complex arithmetic, composition, and
 - **3D rotations (SU(2))**: `QA`, `QB` (device), `RA`, `RB` (trackball).
 - **Literals:** `1.25`, `-3.5`, `2+3i`, `0,1`, `i`, `-i`, `j` (for `-½ + √3/2 i`).
 - **Operators:** `+`, `-`, `*`, `/`, power (`^` with integer exponents), composition (`o(f, g)` or `f $ g`), repeated composition (`oo(f, n)` or `f $$ n`).
+- **Loops:** `repeat n from a1, a2, ..., ak by f1, f2, ..., fk` iterates a **k-register state** for `n` steps and returns the final `r1`.
+  - `n` must be a **compile-time integer** (e.g. `10`, `floor(3.9)`); if `n <= 0` it performs zero iterations and returns `a1`.
+  - Each `fj` must be a **user-defined** `let` function with exactly `k+1` parameters: `fj(i, r1, ..., rk)`.
   - Dot composition is equivalent: `f $ expr` is the same as `expr.f` (so `a.b` means `b(a(z))`).
 - **Functions:** `exp`, `sin`, `cos`, `tan`, `atan`/`arctan`, `arg`/`argument`, `asin`/`arcsin`, `acos`/`arccos`, `ln`, `sqrt`, `abs`/`modulus`, `abs2`, `floor`, `conj`, `heav`, `isnan`, `ifnan`/`iferror`. `sqrt(z, k)` desugars to `exp(0.5 * ln(z, k))`, so the optional second argument shifts the log branch; `heav(x)` evaluates to `1` when `x > 0` and `0` otherwise.
 - **Conditionals:** comparisons (`<`, `<=`, `>`, `>=`, `==`), logical ops (`&&`, `||`), and `if(cond, then, else)`.
@@ -278,6 +281,36 @@ fn
 ```
 
 This means apply \(z \mapsto z^2 + 0.1\) four times.
+
+### Loops (`repeat`) examples
+
+All examples below return a **single complex value** (no tuples/arrays are introduced at runtime).
+
+```text
+# Sum of integers: 0 + 1 + ... + 9 = 45
+let step(i, s) = s + i in
+repeat 10 from 0 by step
+
+# Sum of squares: 0^2 + 1^2 + ... + 9^2 = 285
+let step(i, s) = s + i*i in
+repeat 10 from 0 by step
+
+# Alternate sum of cubes: Σ (-1)^i * i^3 for i=0..9
+let fs(i, s, sign) = s + sign*(i^3) in
+let fsign(i, s, sign) = -sign in
+repeat 10 from 0, 1 by fs, fsign
+
+# Sum of fourth powers: Σ i^4 for i=0..9
+let step(i, s) = s + i^4 in
+repeat 10 from 0 by step
+
+# Truncated exp series (n terms): Σ z^i / i! for i=0..n-1
+# Registers: (sum, term, zConst). Keep zConst unchanged across iterations.
+let fsum(i, sum, term, zc) = sum + term in
+let fterm(i, sum, term, zc) = term * zc / (i + 1) in
+let fz(i, sum, term, zc) = zc in
+repeat 12 from 0, 1, z by fsum, fterm, fz
+```
 
 Tips:
 

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -1128,3 +1128,9 @@ repeat 1.5 from 0 by step
   assert.equal(result.ok, false);
   assert.match(result.message, /integer iteration count/i);
 });
+
+test('repeat keyword commits (repeat is not treated as an identifier)', () => {
+  const result = parseFormulaInput('repeat');
+  assert.equal(result.ok, false);
+  assert.match(result.message, /iteration count/i);
+});

--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -107,6 +107,11 @@ export function childEntries(node) {
         ['base', node.base],
         ['countExpression', node.countExpression],
       ];
+    case 'Repeat':
+      return [
+        ['countExpression', node.countExpression],
+        ['fromExpressions', Array.isArray(node.fromExpressions) ? node.fromExpressions : []],
+      ];
     case 'LetBinding':
       return [
         ['value', node.value],

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1307,7 +1307,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=33.0';
+    const SW_URL = './service-worker.js?sw=34.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=33.0';
+  const SW_URL = './service-worker.js?sw=34.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -14,6 +14,7 @@ function precedence(node) {
     case 'Call':
       return 9;
     case 'SetBinding':
+    case 'Repeat':
     case 'If':
     case 'IfNaN':
       return 1;
@@ -448,6 +449,16 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
       const value = nodeToLatex(node.value, 0, options);
       const body = nodeToLatex(node.body, 0, options);
       return `\\left(\\begin{aligned}\\mathrm{set}\\;${name} &= ${value}\\\\&${body}\\end{aligned}\\right)`;
+    }
+
+    case 'Repeat': {
+      // Keep `repeat ... from ... by ...` as a first-class construct in rendering.
+      const n = node.countExpression ? nodeToLatex(node.countExpression, 0, options) : '?';
+      const fromExprs = Array.isArray(node.fromExpressions) ? node.fromExpressions : [];
+      const fromLatex = fromExprs.length ? fromExprs.map((e) => nodeToLatex(e, 0, options)).join(', ') : '?';
+      const byNames = Array.isArray(node.byIdentifiers) ? node.byIdentifiers : [];
+      const byLatex = byNames.length ? byNames.map((name) => escapeLatexIdentifier(name)).join(', ') : '?';
+      return `\\left(\\begin{aligned}\\mathrm{repeat}\\;${n}\\\\\\mathrm{from}\\;${fromLatex}\\\\\\mathrm{by}\\;${byLatex}\\end{aligned}\\right)`;
     }
 
     default:

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1026,7 +1026,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v33</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v34</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -57,7 +57,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 33;
+const APP_VERSION = 34;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4011,7 +4011,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=33.0';
+  const SW_URL = './service-worker.js?sw=34.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '33.0';
+const CACHE_MINOR = '34.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Adds a `repeat ... from ... by ...` looping construct to the Reflex4You language for compile-time unrolled state vector iteration.

This construct desugars into hygienic `set` bindings, ensuring compatibility with GPU backends and avoiding runtime tuple/array overhead. It also includes a fix for the `i` identifier, allowing it to be used as a loop index parameter while preserving its legacy meaning as the imaginary unit when unbound.

---
<a href="https://cursor.com/background-agent?bcId=bc-efc2636f-63d7-4fd5-8fb1-e577493961e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-efc2636f-63d7-4fd5-8fb1-e577493961e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

