### PR TITLE
Formula sum prod power

### DIFF
--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -506,12 +506,11 @@ const boundIdentifierParser = createParser('BoundIdentifier', (input) => {
   }
   const normalized = normalizeIdentifierWithHighlights(identifier.value);
   // Disallow reserved names and finger labels (same constraints as `let`/`set` bindings),
-  // plus a couple internal names used by repeat helpers.
+  // but do NOT reserve internal helper parameter names (those are handled by alpha-renaming
+  // in the late lowering pass).
   if (
     RESERVED_BINDING_NAMES.has(normalized.name) ||
-    isFingerLabel(normalized.name) ||
-    normalized.name === 'iter' ||
-    normalized.name === 'acc'
+    isFingerLabel(normalized.name)
   ) {
     return new ParseFailure({
       ctor: 'BoundIdentifier',

--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -1101,6 +1101,8 @@ const dotExpressionParser = createParser('DotExpression', (input) => {
     }
     const span = spanBetween(input, suffix.next);
     node = withSpan(Compose(suffix.value, node), span);
+    // Preserve dot syntax for rendering decisions.
+    node.composeSyntax = 'dot';
     cursor = suffix.next;
   }
   const span = spanBetween(input, cursor);

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -1149,14 +1149,14 @@ test('sum/prod: display preserves sum/prod surface syntax', () => {
   assert.equal(sumResult.ok, true);
   assert.equal(sumResult.value.kind, 'Sum');
   const sumLatex = formulaAstToLatex(sumResult.value);
-  assert.match(sumLatex, /\\operatorname\{sum\}/);
+  assert.match(sumLatex, /\\sum/);
   assert.doesNotMatch(sumLatex, /\\mathrm\{repeat\}/);
 
   const prodResult = parseFormulaInput('prod(k, k, 0, 10)');
   assert.equal(prodResult.ok, true);
   assert.equal(prodResult.value.kind, 'Prod');
   const prodLatex = formulaAstToLatex(prodResult.value);
-  assert.match(prodLatex, /\\operatorname\{prod\}/);
+  assert.match(prodLatex, /\\prod/);
   assert.doesNotMatch(prodLatex, /\\mathrm\{repeat\}/);
 });
 

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -1194,6 +1194,16 @@ test('sum/prod: semantic correctness via repeat lowering', () => {
   assert.equal(sumNeg.im, 0);
 });
 
+test('sum/prod: bound variable can be named acc/iter (no conflicts with lowering helpers)', () => {
+  const sumAcc = evalLowered('sum(acc, acc, 1, 3)');
+  assert.equal(sumAcc.re, 6);
+  assert.equal(sumAcc.im, 0);
+
+  const sumIter = evalLowered('sum(iter, iter, 1, 3)');
+  assert.equal(sumIter.re, 6);
+  assert.equal(sumIter.im, 0);
+});
+
 test('sum/prod: complex-valued body works (without using i as a variable)', () => {
   const value = evalLowered('sum(k + i, k, 1, 2)');
   assert.equal(value.re, 3);

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -595,6 +595,8 @@ test('dot composition syntax treats a.b as (b $ a)', () => {
   assert.equal(node.g.kind, 'FingerOffset');
   assert.equal(node.g.slot, 'D1');
   assert.equal(node.f.kind, 'VarX');
+  // Dot syntax should be preserved for rendering decisions.
+  assert.equal(node.composeSyntax, 'dot');
 });
 
 test('dot composition chains associate left-to-right', () => {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -6,7 +6,7 @@ import {
 } from './arithmetic-parser.mjs';
 import { visitAst } from './ast-utils.mjs';
 import { formulaAstToLatex } from './formula-renderer.mjs';
-import { buildFragmentSourceFromAST } from './core-engine.mjs';
+import { buildFragmentSourceFromAST, lowerHighLevelSugar } from './core-engine.mjs';
 
 test('parses additive and multiplicative precedence', () => {
   const result = parseFormulaInput('1 + 2 * 3');
@@ -90,51 +90,50 @@ test('parentheses can force (-z)^4', () => {
   assert.equal(result.value.base.kind, 'Sub');
 });
 
-test('non-integer exponents lower to exp form', () => {
+test('non-integer exponents preserve power surface syntax', () => {
   const result = parseFormulaInput('z ^ 1.5');
   assert.equal(result.ok, true);
-  assert.equal(result.value.kind, 'Exp');
-  assert.equal(result.value.value.kind, 'Mul');
-  assert.equal(result.value.value.left.kind, 'Const');
+  assert.equal(result.value.kind, 'PowExpr');
+  const latex = formulaAstToLatex(result.value);
+  assert.doesNotMatch(latex, /\\exp|\\ln/);
 });
 
-test('power expressions simplify to Pow when exponent is an integer expression', () => {
+test('power expressions preserve power surface syntax (even if exponent is constant-foldable)', () => {
   const result = parseFormulaInput('z ^ (1 + 1)');
   assert.equal(result.ok, true);
-  assert.equal(result.value.kind, 'Pow');
-  assert.equal(result.value.exponent, 2);
+  assert.equal(result.value.kind, 'PowExpr');
 });
 
-test('set-bound integer exponent resolves to Pow', () => {
+test('set-bound integer exponent remains a power expression (optimized later)', () => {
   const result = parseFormulaInput('set n = 3 in z ^ n');
   assert.equal(result.ok, true);
   const binding = result.value;
   assert.equal(binding.kind, 'SetBinding');
-  assert.equal(binding.body.kind, 'Pow');
-  assert.equal(binding.body.exponent, 3);
+  assert.equal(binding.body.kind, 'PowExpr');
+  assert.equal(binding.body.__resolvedIntExp, 3);
 });
 
-test('symbolic non-integer exponents remain in exp form', () => {
+test('symbolic non-integer exponents preserve power surface syntax', () => {
   const result = parseFormulaInput('z ^ x');
   assert.equal(result.ok, true);
-  assert.equal(result.value.kind, 'Exp');
+  assert.equal(result.value.kind, 'PowExpr');
 });
 
-test('power exponents beyond threshold fall back to exp form', () => {
+test('power exponents beyond Pow threshold remain power expressions', () => {
   const result = parseFormulaInput('z ^ 11');
   assert.equal(result.ok, true);
-  assert.equal(result.value.kind, 'Exp');
+  assert.equal(result.value.kind, 'PowExpr');
 });
 
-test('power exponents from finger-based constants collapse to Pow', () => {
+test('power exponents from finger-based constants remain power expressions (optimized later)', () => {
   const result = parseFormulaInput('z ^ (F1.x + 1)', {
     fingerValues: {
       F1: { x: 2, y: 0 },
     },
   });
   assert.equal(result.ok, true);
-  assert.equal(result.value.kind, 'Pow');
-  assert.equal(result.value.exponent, 3);
+  assert.equal(result.value.kind, 'PowExpr');
+  assert.equal(result.value.__resolvedIntExp, 3);
 });
 
 test('parses exp/sin/cos/ln calls', () => {
@@ -937,6 +936,10 @@ function evaluateAstComplex(root, { z = { re: 0, im: 0 } } = {}) {
         return complexMul(evalNode(node.left, zLocal, localParamEnv, localSetEnv, localLetEnv), evalNode(node.right, zLocal, localParamEnv, localSetEnv, localLetEnv));
       case 'Div':
         return complexDiv(evalNode(node.left, zLocal, localParamEnv, localSetEnv, localLetEnv), evalNode(node.right, zLocal, localParamEnv, localSetEnv, localLetEnv));
+      case 'Floor': {
+        const v = evalNode(node.value, zLocal, localParamEnv, localSetEnv, localLetEnv);
+        return { re: Math.floor(v.re), im: 0 };
+      }
       case 'SetBinding': {
         const value = evalNode(node.value, zLocal, localParamEnv, localSetEnv, localLetEnv);
         const nextSetEnv = new Map(localSetEnv);
@@ -1029,6 +1032,12 @@ function evaluateAstComplex(root, { z = { re: 0, im: 0 } } = {}) {
   }
 
   return evalNode(root, z, paramEnv, setEnv, letEnv);
+}
+
+function evalLowered(source) {
+  const ast = parseFormulaToAST(source);
+  const lowered = lowerHighLevelSugar(ast);
+  return evaluateAstComplex(lowered);
 }
 
 test('repeat: single register increments', () => {
@@ -1133,4 +1142,78 @@ test('repeat keyword commits (repeat is not treated as an identifier)', () => {
   const result = parseFormulaInput('repeat');
   assert.equal(result.ok, false);
   assert.match(result.message, /iteration count/i);
+});
+
+test('sum/prod: display preserves sum/prod surface syntax', () => {
+  const sumResult = parseFormulaInput('sum(k, k, 0, 10)');
+  assert.equal(sumResult.ok, true);
+  assert.equal(sumResult.value.kind, 'Sum');
+  const sumLatex = formulaAstToLatex(sumResult.value);
+  assert.match(sumLatex, /\\operatorname\{sum\}/);
+  assert.doesNotMatch(sumLatex, /\\mathrm\{repeat\}/);
+
+  const prodResult = parseFormulaInput('prod(k, k, 0, 10)');
+  assert.equal(prodResult.ok, true);
+  assert.equal(prodResult.value.kind, 'Prod');
+  const prodLatex = formulaAstToLatex(prodResult.value);
+  assert.match(prodLatex, /\\operatorname\{prod\}/);
+  assert.doesNotMatch(prodLatex, /\\mathrm\{repeat\}/);
+});
+
+test('sum/prod: optional step is preserved in display', () => {
+  const result = parseFormulaInput('sum(k, k, 0, 10, 2)');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /\\operatorname\{sum\}/);
+  assert.match(latex, /, 2\\right\)/);
+});
+
+test('fractional powers stay as powers in display (including inside sum)', () => {
+  const result = parseFormulaInput('sum(z^0.5, n, 1, 2)');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /z\^\{0\.5\}/);
+  assert.doesNotMatch(latex, /\\exp|\\ln/);
+});
+
+test('sum/prod: semantic correctness via repeat lowering', () => {
+  const sum14 = evalLowered('sum(k, k, 1, 4)');
+  assert.equal(sum14.re, 10);
+  assert.equal(sum14.im, 0);
+
+  const prod14 = evalLowered('prod(k, k, 1, 4)');
+  assert.equal(prod14.re, 24);
+  assert.equal(prod14.im, 0);
+
+  const sumStep = evalLowered('sum(k, k, 1, 5, 2)');
+  assert.equal(sumStep.re, 9);
+  assert.equal(sumStep.im, 0);
+
+  const sumNeg = evalLowered('sum(k, k, 5, 1, -2)');
+  assert.equal(sumNeg.re, 9);
+  assert.equal(sumNeg.im, 0);
+});
+
+test('sum/prod: complex-valued body works (without using i as a variable)', () => {
+  const value = evalLowered('sum(k + i, k, 1, 2)');
+  assert.equal(value.re, 3);
+  assert.equal(value.im, 2);
+});
+
+test('sum/prod: scope/capture (bound var shadows outer set binding)', () => {
+  const value = evalLowered('set k = 999 in sum(k, k, 1, 3)');
+  assert.equal(value.re, 6);
+  assert.equal(value.im, 0);
+});
+
+test('sum/prod: nested sums reuse same bound name without capture', () => {
+  const value = evalLowered('sum(sum(k, k, 1, 2), k, 1, 2)');
+  assert.equal(value.re, 6);
+  assert.equal(value.im, 0);
+});
+
+test('sum/prod: rejects non-compile-time bounds (repeat-count rule)', () => {
+  const result = parseFormulaInput('sum(k, k, 1, x)');
+  assert.equal(result.ok, false);
+  assert.match(result.message, /compile time/i);
 });

--- a/apps/reflex4you/ast-utils.mjs
+++ b/apps/reflex4you/ast-utils.mjs
@@ -33,6 +33,19 @@ export function childEntries(node) {
   switch (node.kind) {
     case 'Pow':
       return [['base', node.base]];
+    case 'PowExpr':
+      return [
+        ['base', node.base],
+        ['exponent', node.exponent],
+      ];
+    case 'Sum':
+    case 'Prod':
+      return [
+        ['body', node.body],
+        ['min', node.min],
+        ['max', node.max],
+        ['step', node.step],
+      ];
     case 'Exp':
     case 'Sin':
     case 'Cos':

--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -817,6 +817,16 @@ export function lowerHighLevelSugar(ast) {
     }
   }
 
+  function freshParam(prefix, avoidNames = new Set()) {
+    const avoid = avoidNames instanceof Set ? avoidNames : new Set(avoidNames || []);
+    while (true) {
+      const candidate = `${prefix}_${nextId++}`;
+      if (!avoid.has(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
   function replace(parent, key, replacement) {
     if (parent && key != null) {
       parent[key] = replacement;
@@ -902,9 +912,12 @@ export function lowerHighLevelSugar(ast) {
         const nBinding = SetBindingNode(nName, nValue, null);
         const nRef = SetRef(nName, nBinding);
 
-        const iterParam = 'iter';
-        const accParam = 'acc';
         const vParam = String(node.varName || 'v');
+        const avoidParams = new Set([vParam]);
+        const iterParam = freshParam(`r4y_${node.kind.toLowerCase()}_iter`, avoidParams);
+        avoidParams.add(iterParam);
+        const accParam = freshParam(`r4y_${node.kind.toLowerCase()}_acc`, avoidParams);
+        avoidParams.add(accParam);
 
         const accUpdate =
           node.kind === 'Sum'

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1307,7 +1307,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=35.0';
+    const SW_URL = './service-worker.js?sw=36.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1307,7 +1307,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=36.0';
+    const SW_URL = './service-worker.js?sw=36.1';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=36.0';
+  const SW_URL = './service-worker.js?sw=36.1';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=35.0';
+  const SW_URL = './service-worker.js?sw=36.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -459,10 +459,56 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
     case 'GreaterThanOrEqual':
     case 'Equal':
     case 'LogicalAnd':
-    case 'LogicalOr':
-    case 'Compose':
-      // handled above
-      return '?';
+    case 'LogicalOr': {
+      const prec = precedence(node);
+      const leftNode = node.left;
+      const rightNode = node.right;
+      const left = nodeToLatex(leftNode, prec, options);
+      const right = nodeToLatex(rightNode, prec, options);
+
+      const leftWrapped = maybeWrapLatex(leftNode, left, prec, 'left', node.kind);
+      const rightWrapped = maybeWrapLatex(rightNode, right, prec, 'right', node.kind);
+
+      switch (node.kind) {
+        case 'Add': {
+          return `${leftWrapped} + ${rightWrapped}`;
+        }
+        case 'Sub': {
+          return `${leftWrapped} - ${rightWrapped}`;
+        }
+        case 'Mul': {
+          // Use a thin space instead of `\\cdot` for readability.
+          return `${leftWrapped}\\,${rightWrapped}`;
+        }
+        case 'Div': {
+          // Prefer fractions for readability; they behave as an "atomic" group in TeX.
+          return `\\frac{${left}}{${right}}`;
+        }
+        case 'LessThan': {
+          return `${leftWrapped} < ${rightWrapped}`;
+        }
+        case 'GreaterThan': {
+          return `${leftWrapped} > ${rightWrapped}`;
+        }
+        case 'LessThanOrEqual': {
+          return `${leftWrapped} \\le ${rightWrapped}`;
+        }
+        case 'GreaterThanOrEqual': {
+          return `${leftWrapped} \\ge ${rightWrapped}`;
+        }
+        case 'Equal': {
+          return `${leftWrapped} = ${rightWrapped}`;
+        }
+        case 'LogicalAnd': {
+          return `${leftWrapped} \\land ${rightWrapped}`;
+        }
+        case 'LogicalOr': {
+          return `${leftWrapped} \\lor ${rightWrapped}`;
+        }
+        default:
+          return '?';
+      }
+    }
 
     case 'If': {
       const cond = nodeToLatex(node.condition, 0, options);

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1026,7 +1026,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v35</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v36</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -4017,7 +4017,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=36.0';
+  const SW_URL = './service-worker.js?sw=36.1';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -57,7 +57,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 35;
+const APP_VERSION = 36;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4017,7 +4017,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=35.0';
+  const SW_URL = './service-worker.js?sw=36.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/package-lock.json
+++ b/apps/reflex4you/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reflex4you",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reflex4you",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "devDependencies": {
         "@playwright/test": "^1.48.2",
         "http-server": "^14.1.1"

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '35.0';
+const CACHE_MINOR = '36.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '36.0';
+const CACHE_MINOR = '36.1';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -99,6 +99,20 @@ test('formula page renders underscore-highlight metadata letters as Huge (LEON)'
   expect(value.indexOf('{\\Huge O}')).toBeLessThan(value.indexOf('{\\Huge N}'));
 });
 
+test('formula page renders sum(...) with fractional powers and $$ repeat composition', async ({ page }) => {
+  const source = 'sum(-(-1)^n*(z-D2)^n/n, n, 1, (D1.x*10).floor,1) $$ 8';
+  await page.goto(`/formula.html?formula=${encodeURIComponent(source)}`);
+  const render = page.locator('#formula-render');
+  await expect(render).toBeVisible();
+  await expect.poll(async () => await render.getAttribute('data-latex')).toContain('\\operatorname{sum}');
+  // Preserve power surface syntax for non-integer powers; in this formula, `^n` stays as a power
+  // in display (not lowered to exp/ln).
+  await expect.poll(async () => await render.getAttribute('data-latex')).not.toContain('\\exp');
+  await expect.poll(async () => await render.getAttribute('data-latex')).not.toContain('\\ln');
+  // $$ 8 renders as a repeat composition superscript.
+  await expect.poll(async () => await render.getAttribute('data-latex')).toContain('\\circ 8');
+});
+
 test('reflex4you updates formula query param after successful apply', async ({ page }) => {
   await page.goto('/index.html');
   await waitForReflexReady(page);

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -104,13 +104,26 @@ test('formula page renders sum(...) with fractional powers and $$ repeat composi
   await page.goto(`/formula.html?formula=${encodeURIComponent(source)}`);
   const render = page.locator('#formula-render');
   await expect(render).toBeVisible();
-  await expect.poll(async () => await render.getAttribute('data-latex')).toContain('\\operatorname{sum}');
+  await expect.poll(async () => await render.getAttribute('data-latex')).toContain('\\sum');
   // Preserve power surface syntax for non-integer powers; in this formula, `^n` stays as a power
   // in display (not lowered to exp/ln).
   await expect.poll(async () => await render.getAttribute('data-latex')).not.toContain('\\exp');
   await expect.poll(async () => await render.getAttribute('data-latex')).not.toContain('\\ln');
   // $$ 8 renders as a repeat composition superscript.
   await expect.poll(async () => await render.getAttribute('data-latex')).toContain('\\circ 8');
+});
+
+test('formula page keeps _sum(...) as function call so highlighted letters can render', async ({ page }) => {
+  const source = '_sum(z, n, 1, 2)';
+  await page.goto(`/formula.html?formula=${encodeURIComponent(source)}`);
+  const render = page.locator('#formula-render');
+  await expect(render).toBeVisible();
+  await expect.poll(async () => await render.getAttribute('data-latex')).not.toBeNull();
+  const latex = String(await render.getAttribute('data-latex') || '');
+  expect(latex).toContain('\\operatorname');
+  expect(latex).toContain('{\\Huge');
+  expect(latex).toContain('\\left(');
+  expect(latex).not.toContain('\\sum_{');
 });
 
 test('reflex4you updates formula query param after successful apply', async ({ page }) => {

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -82,6 +82,16 @@ test('formula page does not double-parenthesize factors for multiplication', asy
   expect(latex).not.toContain('\\cdot');
 });
 
+test('formula page renders D1.x.floor without composition glyphs or black rectangles', async ({ page }) => {
+  await page.goto(`/formula.html?formula=${encodeURIComponent('D1.x.floor')}`);
+  const render = page.locator('#formula-render');
+  await expect(render).toBeVisible();
+  await expect.poll(async () => await render.getAttribute('data-latex')).toContain('\\left\\lfloor');
+  const latex = String(await render.getAttribute('data-latex') || '');
+  expect(latex).toContain('\\mathrm{D}_{1}.x');
+  expect(latex).not.toContain('\\circ');
+});
+
 test('formula page renders underscore-highlight metadata letters as Huge (LEON)', async ({ page }) => {
   const source = '_ln(_exp(_o(si_n, z*z)-3)-1)';
   await page.goto(`/formula.html?formula=${encodeURIComponent(source)}`);


### PR DESCRIPTION
Introduce `Sum`, `Prod`, and `PowExpr` AST nodes and update the LaTeX renderer to preserve their surface syntax in displayed formulas.

---
<a href="https://cursor.com/background-agent?bcId=bc-24ecc435-8441-4eb4-8649-187ad74edf6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24ecc435-8441-4eb4-8649-187ad74edf6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

