### PR TITLE
Math symbol display

### DIFF
--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -75,11 +75,13 @@ function normalizeIdentifierWithHighlights(raw) {
 
   for (let i = 0; i < source.length; i += 1) {
     const ch = source[i];
-    if (ch === '_' && i + 1 < source.length && IDENTIFIER_LETTER_CHAR.test(source[i + 1])) {
+    // In Reflex syntax, underscores are not part of identifiers: they only mean
+    // "highlight the next character" (whatever it is).
+    if (ch === '_' && i + 1 < source.length) {
       highlightNext = true;
       continue;
     }
-    if (highlightNext && IDENTIFIER_LETTER_CHAR.test(ch)) {
+    if (highlightNext) {
       highlights.push({ index: normalized.length, letter: ch });
       highlightNext = false;
     } else {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -166,11 +166,13 @@ test('renders greek-letter identifiers as symbols (unless underscores are presen
   assert.match(latex, /\\delta/);
   assert.match(latex, /\\phi/);
 
-  const underscored = parseFormulaInput('set pi_1 = 0 in pi_1');
-  assert.equal(underscored.ok, true);
-  const underscoredLatex = formulaAstToLatex(underscored.value);
-  assert.match(underscoredLatex, /pi\\_1/);
-  assert.doesNotMatch(underscoredLatex, /\\pi/);
+  // Underscore is a highlight marker, not part of the identifier:
+  // `pi_1` becomes identifier `pi1` with a highlighted "1" (so it is not a greek-letter symbol).
+  const highlighted = parseFormulaInput('set pi_1 = 0 in pi_1');
+  assert.equal(highlighted.ok, true);
+  const highlightedLatex = formulaAstToLatex(highlighted.value);
+  assert.doesNotMatch(highlightedLatex, /\\pi/);
+  assert.match(highlightedLatex, /\{\\Huge 1\}/);
 });
 
 test('renders gamma_1 as "gamma" followed by a big 1', () => {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -167,11 +167,13 @@ test('renders greek-letter identifiers as symbols (unless underscores are presen
   assert.match(latex, /\\phi/);
 
   // Underscore is a highlight marker, not part of the identifier:
-  // `pi_1` becomes identifier `pi1` with a highlighted "1" (so it is not a greek-letter symbol).
+  // `pi_1` becomes identifier `pi1` with a highlighted "1".
   const highlighted = parseFormulaInput('set pi_1 = 0 in pi_1');
   assert.equal(highlighted.ok, true);
   const highlightedLatex = formulaAstToLatex(highlighted.value);
-  assert.doesNotMatch(highlightedLatex, /\\pi/);
+  // Binding name is rendered without highlight metadata, so it becomes \pi_{1}.
+  assert.match(highlightedLatex, /\\pi_\{1\}/);
+  // The reference keeps the digit highlight, so the 1 is rendered Huge (in the subscript).
   assert.match(highlightedLatex, /\{\\Huge 1\}/);
 });
 
@@ -181,6 +183,20 @@ test('renders gamma_1 as "gamma" followed by a big 1', () => {
   const latex = formulaAstToLatex(result.value);
   assert.match(latex, /\\mathrm\{gamma\}/);
   assert.match(latex, /\{\\Huge 1\}/);
+});
+
+test('renders identifier trailing digits as subscripts (d1 -> d_{1})', () => {
+  const result = parseFormulaInput('set d1 = 0 in d1');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /d_\{1\}/);
+});
+
+test('renders greek identifiers with digit suffix as subscripts (pi1 -> \\pi_{1})', () => {
+  const result = parseFormulaInput('set pi1 = 0 in pi1');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /\\pi_\{1\}/);
 });
 
 test('parses gamma(...) as a primitive and renders with Γ', () => {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -143,6 +143,44 @@ test('parses exp/sin/cos/ln calls', () => {
   assert.equal(result.value.value.kind, 'Sin');
 });
 
+test('renders exp(x) as e^{x} (unless underscore-highlight syntax is used)', () => {
+  const plain = parseFormulaInput('exp(z)');
+  assert.equal(plain.ok, true);
+  const plainLatex = formulaAstToLatex(plain.value);
+  assert.match(plainLatex, /^e\^\{z\}$/);
+
+  const highlighted = parseFormulaInput('_exp(z)');
+  assert.equal(highlighted.ok, true);
+  const highlightedLatex = formulaAstToLatex(highlighted.value);
+  assert.match(highlightedLatex, /\\operatorname\{/);
+  assert.match(highlightedLatex, /\{\\Huge/);
+  assert.match(highlightedLatex, /\\left\(z\\right\)/);
+});
+
+test('renders greek-letter identifiers as symbols (unless underscores are present)', () => {
+  const result = parseFormulaInput('set pi = 0 in set tau = 0 in set delta = 0 in set phi = 0 in pi + tau + delta + phi');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /\\pi/);
+  assert.match(latex, /\\tau/);
+  assert.match(latex, /\\delta/);
+  assert.match(latex, /\\phi/);
+
+  const underscored = parseFormulaInput('set pi_1 = 0 in pi_1');
+  assert.equal(underscored.ok, true);
+  const underscoredLatex = formulaAstToLatex(underscored.value);
+  assert.match(underscoredLatex, /pi\\_1/);
+  assert.doesNotMatch(underscoredLatex, /\\pi/);
+});
+
+test('renders gamma_1 as "gamma" followed by a big 1', () => {
+  const result = parseFormulaInput('set gamma_1 = 0 in gamma_1');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /\\mathrm\{gamma\}/);
+  assert.match(latex, /\{\\Huge 1\}/);
+});
+
 test('parses gamma(...) as a primitive and renders with Γ', () => {
   const result = parseFormulaInput('gamma(z)');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -4,7 +4,7 @@
 import { FINGER_DECIMAL_PLACES } from './core-engine.mjs';
 
 // Bump this when changing renderer logic so users can verify cached assets.
-export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2026-01-13.1';
+export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2026-01-13.2';
 
 const DEFAULT_MATHJAX_LOAD_TIMEOUT_MS = 9000;
 
@@ -125,24 +125,26 @@ function latexIdentifierWithMetadata(name, metaHighlights) {
   if (!highlights.length) {
     const raw = String(name || '?');
 
-    // Special-case: render gamma_1 (and gamma_<digits>) as "gamma" + big digits.
-    // This is explicitly requested even though it contains an underscore.
-    const gammaIndexMatch = raw.match(/^gamma_(\d+)$/);
-    if (gammaIndexMatch) {
-      const digits = gammaIndexMatch[1];
-      return `\\mathrm{gamma}\\,{\\Huge ${digits}}`;
-    }
-
     // Render common greek-letter identifiers as their TeX symbols.
-    // Do not apply when the identifier contains underscores (underscore-highlight or otherwise),
-    // and do not remap "gamma" (it is reserved for the Euler Gamma function).
-    if (!raw.includes('_') && raw !== 'gamma') {
+    // Do not remap "gamma" (it is reserved for the Euler Gamma function).
+    if (raw !== 'gamma') {
       const greek = GREEK_IDENTIFIER_LATEX[raw];
       if (greek) return greek;
     }
 
     return escapeLatexIdentifier(raw);
   }
+
+  // Special-case: render `gamma_1` input as a plain "gamma" word + big digit(s).
+  // With underscore-as-highlight semantics, the identifier name becomes `gamma1`
+  // (and the digit(s) are present in `highlights`).
+  const raw = String(name || '?');
+  const gammaDigitsMatch = raw.match(/^gamma(\d+)$/);
+  if (gammaDigitsMatch) {
+    const digits = gammaDigitsMatch[1];
+    return `\\mathrm{gamma}\\,{\\Huge ${digits}}`;
+  }
+
   return renderTextWithHighlights(name, highlights);
 }
 

--- a/apps/reflex4you/package-lock.json
+++ b/apps/reflex4you/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reflex4you",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reflex4you",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "devDependencies": {
         "@playwright/test": "^1.48.2",
         "http-server": "^14.1.1"

--- a/apps/reflex4you/package-lock.json
+++ b/apps/reflex4you/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reflex4you",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reflex4you",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "devDependencies": {
         "@playwright/test": "^1.48.2",
         "http-server": "^14.1.1"

--- a/apps/reflex4you/package-lock.json
+++ b/apps/reflex4you/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reflex4you",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reflex4you",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "devDependencies": {
         "@playwright/test": "^1.48.2",
         "http-server": "^14.1.1"

--- a/apps/reflex4you/package.json
+++ b/apps/reflex4you/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflex4you",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Local tooling for the Reflex4You app",
   "scripts": {
     "test": "playwright test",

--- a/apps/reflex4you/package.json
+++ b/apps/reflex4you/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflex4you",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Local tooling for the Reflex4You app",
   "scripts": {
     "test": "playwright test",

--- a/apps/reflex4you/package.json
+++ b/apps/reflex4you/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflex4you",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Local tooling for the Reflex4You app",
   "scripts": {
     "test": "playwright test",


### PR DESCRIPTION
Improve `reflex4you` formula rendering to display `exp(x)` as `e^x`, Greek letters as symbols, and `gamma_#` with a large subscript, respecting underscore-highlighting.

---
<a href="https://cursor.com/background-agent?bcId=bc-270d9c2f-2200-4b32-b585-472f91efe958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-270d9c2f-2200-4b32-b585-472f91efe958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

