### PR TITLE
Pwa offline formula update

### DIFF
--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1317,7 +1317,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=37.2';
+    const SW_URL = './service-worker.js?sw=38.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=37.2';
+  const SW_URL = './service-worker.js?sw=38.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1034,7 +1034,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v37</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v38</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -57,7 +57,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 37;
+const APP_VERSION = 38;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4048,7 +4048,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=37.2';
+  const SW_URL = './service-worker.js?sw=38.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '37.2';
+const CACHE_MINOR = '38.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Fix offline formula compilation errors by reusing the WebWorker and bump the app major version.

When editing a formula offline, the app would fail to compile because recreating the compilation WebWorker could trigger network requests for its modules, which would then fail. By reusing the existing worker, these unnecessary network fetches are avoided, ensuring offline formula updates work correctly. A recovery path was also added for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-aab5a3cf-e918-4285-b87c-b3a5dc919706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aab5a3cf-e918-4285-b87c-b3a5dc919706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

