### PR TITLE
Focus mode UI

### DIFF
--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1317,7 +1317,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=38.0';
+    const SW_URL = './service-worker.js?sw=39.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=38.0';
+  const SW_URL = './service-worker.js?sw=39.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -792,6 +792,37 @@
       pointer-events: none !important;
     }
 
+    /* Focus mode: hide UI chrome, keep a transparent menu. */
+    html.focus-mode #formula-panel,
+    html.focus-mode #finger-indicator-stack,
+    html.focus-mode #finger-overlay,
+    html.focus-mode #error,
+    html.focus-mode #compile-overlay,
+    html.focus-mode #app-version-pill,
+    html.focus-mode #undo-button,
+    html.focus-mode #redo-button {
+      display: none !important;
+      visibility: hidden !important;
+      pointer-events: none !important;
+    }
+
+    html.focus-mode #menu-button {
+      background: rgba(0, 0, 0, 0.15);
+      border-color: rgba(255, 255, 255, 0.3);
+    }
+
+    html.focus-mode #menu-button:hover,
+    html.focus-mode #menu-button:focus-visible {
+      background: rgba(0, 0, 0, 0.28);
+      border-color: rgba(255, 255, 255, 0.6);
+    }
+
+    html.focus-mode #menu-dropdown {
+      background: rgba(0, 0, 0, 0.3);
+      border-color: rgba(255, 255, 255, 0.22);
+      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+    }
+
     /* Boot/recovery overlay should always be visible, even in viewer mode. */
     #boot-overlay {
       position: fixed;
@@ -1016,6 +1047,15 @@
           Save image
         </button>
         <button
+          id="menu-focus-toggle"
+          type="button"
+          class="menu-dropdown__item"
+          data-menu-action="toggle-focus-mode"
+          role="menuitem"
+        >
+          Enter focus mode
+        </button>
+        <button
           type="button"
           class="menu-dropdown__item"
           data-menu-action="open-formula-view"
@@ -1034,7 +1074,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v38</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v39</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -35,6 +35,7 @@ const fingerIndicatorStack = document.getElementById('finger-indicator-stack');
 const fingerOverlay = document.getElementById('finger-overlay');
 const menuButton = document.getElementById('menu-button');
 const menuDropdown = document.getElementById('menu-dropdown');
+const focusModeMenuItem = document.getElementById('menu-focus-toggle');
 const undoButton = document.getElementById('undo-button');
 const redoButton = document.getElementById('redo-button');
 const versionPill = document.getElementById('app-version-pill');
@@ -57,7 +58,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 38;
+const APP_VERSION = 39;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -301,6 +302,7 @@ const ANIMATION_SUFFIX = 'A';
 
 let viewerModeActive = false;
 let viewerModeRevealed = false;
+let focusModeActive = false;
 
 let animationSeconds = DEFAULT_ANIMATION_SECONDS;
 let animationController = null;
@@ -1840,6 +1842,22 @@ function revealViewerModeUIOnce() {
   }
 }
 
+function updateFocusModeMenuItem() {
+  if (!focusModeMenuItem) {
+    return;
+  }
+  focusModeMenuItem.textContent = focusModeActive ? 'Exit focus mode' : 'Enter focus mode';
+  focusModeMenuItem.setAttribute('aria-pressed', focusModeActive ? 'true' : 'false');
+}
+
+function setFocusModeActive(active) {
+  focusModeActive = Boolean(active);
+  if (rootElement) {
+    rootElement.classList.toggle('focus-mode', focusModeActive);
+  }
+  updateFocusModeMenuItem();
+}
+
 function ensureFingerIndicator(label) {
   // Deprecated: per-finger indicators are no longer rendered.
   return null;
@@ -3106,6 +3124,7 @@ window.addEventListener('resize', () => {
 });
 
 setupMenuDropdown({ menuButton, menuDropdown, onAction: handleMenuAction });
+updateFocusModeMenuItem();
 
 function handleMenuAction(action) {
   switch (action) {
@@ -3148,6 +3167,9 @@ function handleMenuAction(action) {
         console.error('Failed to save canvas image.', error);
         alert('Unable to save image. Check console for details.');
       });
+      break;
+    case 'toggle-focus-mode':
+      setFocusModeActive(!focusModeActive);
       break;
     case 'open-formula-view':
       window.location.href = `./formula.html${window.location.search || ''}`;
@@ -4048,7 +4070,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=38.0';
+  const SW_URL = './service-worker.js?sw=39.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -1846,8 +1846,8 @@ function updateFocusModeMenuItem() {
   if (!focusModeMenuItem) {
     return;
   }
-  focusModeMenuItem.textContent = focusModeActive ? 'Exit focus mode' : 'Enter focus mode';
-  focusModeMenuItem.setAttribute('aria-pressed', focusModeActive ? 'true' : 'false');
+  focusModeMenuItem.textContent = 'Enter focus mode';
+  focusModeMenuItem.removeAttribute('aria-pressed');
 }
 
 function setFocusModeActive(active) {
@@ -3125,6 +3125,13 @@ window.addEventListener('resize', () => {
 
 setupMenuDropdown({ menuButton, menuDropdown, onAction: handleMenuAction });
 updateFocusModeMenuItem();
+if (menuButton) {
+  menuButton.addEventListener('click', () => {
+    if (focusModeActive) {
+      setFocusModeActive(false);
+    }
+  });
+}
 
 function handleMenuAction(action) {
   switch (action) {
@@ -3169,7 +3176,7 @@ function handleMenuAction(action) {
       });
       break;
     case 'toggle-focus-mode':
-      setFocusModeActive(!focusModeActive);
+      setFocusModeActive(true);
       break;
     case 'open-formula-view':
       window.location.href = `./formula.html${window.location.search || ''}`;

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '38.0';
+const CACHE_MINOR = '39.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Add a "focus" mode to the Reflex4You app that hides most UI elements and makes the menu transparent, and bump the app version to v39.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5c8118f-8b56-40dd-a58d-872169a24139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f5c8118f-8b56-40dd-a58d-872169a24139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

