### PR TITLE
Reflex4you exponent rendering

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -90,6 +90,13 @@ test('parentheses can force (-z)^4', () => {
   assert.equal(result.value.base.kind, 'Sub');
 });
 
+test('renders signed bases in exponentiation with parentheses', () => {
+  const result = parseFormulaInput('(-1)^n');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /^\\left\\(-1\\right\\)\\^\\{n\\}$/);
+});
+
 test('non-integer exponents preserve power surface syntax', () => {
   const result = parseFormulaInput('z ^ 1.5');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -97,6 +97,20 @@ test('renders signed bases in exponentiation with parentheses', () => {
   assert.equal(latex, '\\left(-1\\right)^{z}');
 });
 
+test('renders additive bases in exponentiation with parentheses', () => {
+  const result = parseFormulaInput('(1 + 2)^z');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.equal(latex, '\\left(1 + 2\\right)^{z}');
+});
+
+test('renders multiplicative bases in exponentiation with parentheses', () => {
+  const result = parseFormulaInput('(2 * 3)^z');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.equal(latex, '\\left(2\\,3\\right)^{z}');
+});
+
 test('non-integer exponents preserve power surface syntax', () => {
   const result = parseFormulaInput('z ^ 1.5');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -111,6 +111,20 @@ test('renders subtractive complex literals as compact constants', () => {
   assert.equal(latex, '\\left(\\substack{1\\,-\\\\2\\,i}\\right)');
 });
 
+test('renders negative literal in multiplication with parentheses', () => {
+  const result = parseFormulaInput('-1 * 2');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.equal(latex, '\\left(-1\\right)\\,2');
+});
+
+test('renders negative literal on right multiplication with parentheses', () => {
+  const result = parseFormulaInput('2 * -1');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.equal(latex, '2\\,\\left(-1\\right)');
+});
+
 test('renders additive bases in exponentiation with parentheses', () => {
   const result = parseFormulaInput('(1 + 2)^z');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -97,6 +97,20 @@ test('renders signed bases in exponentiation with parentheses', () => {
   assert.equal(latex, '\\left(-1\\right)^{z}');
 });
 
+test('renders additive complex literals as compact constants', () => {
+  const result = parseFormulaInput('1 + 2i');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.equal(latex, '\\left(\\substack{1\\,+\\\\2\\,i}\\right)');
+});
+
+test('renders subtractive complex literals as compact constants', () => {
+  const result = parseFormulaInput('1 - 2i');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.equal(latex, '\\left(\\substack{1\\,-\\\\2\\,i}\\right)');
+});
+
 test('renders additive bases in exponentiation with parentheses', () => {
   const result = parseFormulaInput('(1 + 2)^z');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -94,7 +94,7 @@ test('renders signed bases in exponentiation with parentheses', () => {
   const result = parseFormulaInput('(-1)^z');
   assert.equal(result.ok, true);
   const latex = formulaAstToLatex(result.value);
-  assert.match(latex, /^\\left\\(-1\\right\\)\\^\\{z\\}$/);
+  assert.equal(latex, '\\left(-1\\right)^{z}');
 });
 
 test('non-integer exponents preserve power surface syntax', () => {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -91,10 +91,10 @@ test('parentheses can force (-z)^4', () => {
 });
 
 test('renders signed bases in exponentiation with parentheses', () => {
-  const result = parseFormulaInput('(-1)^n');
+  const result = parseFormulaInput('(-1)^z');
   assert.equal(result.ok, true);
   const latex = formulaAstToLatex(result.value);
-  assert.match(latex, /^\\left\\(-1\\right\\)\\^\\{n\\}$/);
+  assert.match(latex, /^\\left\\(-1\\right\\)\\^\\{z\\}$/);
 });
 
 test('non-integer exponents preserve power surface syntax', () => {

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1317,7 +1317,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=39.0';
+    const SW_URL = './service-worker.js?sw=40.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=39.0';
+  const SW_URL = './service-worker.js?sw=40.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -4,7 +4,7 @@
 import { FINGER_DECIMAL_PLACES } from './core-engine.mjs';
 
 // Bump this when changing renderer logic so users can verify cached assets.
-export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2026-01-17.2';
+export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2026-01-17.3';
 
 const DEFAULT_MATHJAX_LOAD_TIMEOUT_MS = 9000;
 
@@ -199,18 +199,25 @@ function wrapParensLatex(latex) {
   return `\\left(${latex}\\right)`;
 }
 
-function startsWithUnarySign(latex) {
-  const trimmed = String(latex || '').trim();
-  if (!trimmed) return false;
-  return trimmed.startsWith('-') || trimmed.startsWith('+');
+function isSignedLiteralConst(node) {
+  if (!node || typeof node !== 'object' || node.kind !== 'Const') {
+    return false;
+  }
+  if (node.im === 0) {
+    return node.re < 0;
+  }
+  if (node.re === 0) {
+    return node.im < 0;
+  }
+  return false;
 }
 
-function shouldWrapPowerBase(node, latex, parentPrec) {
+function needsPowerBaseParens(node, parentPrec) {
   if (precedence(node) < parentPrec) {
     return true;
   }
-  // Exponentiation binds tighter than unary +/- (e.g. -1^n == -(1^n)).
-  return startsWithUnarySign(latex);
+  // TeX treats unary +/- as lower precedence than exponentiation, so wrap signed literals.
+  return isSignedLiteralConst(node);
 }
 
 function isAtomicForPostfixFactorial(node) {
@@ -404,7 +411,7 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
 
     case 'Pow': {
       const baseLatex = nodeToLatex(node.base, precedence(node), options);
-      const baseWrapped = shouldWrapPowerBase(node.base, baseLatex, precedence(node))
+      const baseWrapped = needsPowerBaseParens(node.base, precedence(node))
         ? wrapParensLatex(baseLatex)
         : baseLatex;
       return `${baseWrapped}^{${formatNumber(node.exponent)}}`;
@@ -412,7 +419,7 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
 
     case 'PowExpr': {
       const baseLatex = nodeToLatex(node.base, precedence(node), options);
-      const baseWrapped = shouldWrapPowerBase(node.base, baseLatex, precedence(node))
+      const baseWrapped = needsPowerBaseParens(node.base, precedence(node))
         ? wrapParensLatex(baseLatex)
         : baseLatex;
       const expLatex = nodeToLatex(node.exponent, 0, options);

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -4,7 +4,7 @@
 import { FINGER_DECIMAL_PLACES } from './core-engine.mjs';
 
 // Bump this when changing renderer logic so users can verify cached assets.
-export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2026-01-17.3';
+export const FORMULA_RENDERER_BUILD_ID = 'reflex4you/formula-renderer build 2026-01-17.4';
 
 const DEFAULT_MATHJAX_LOAD_TIMEOUT_MS = 9000;
 
@@ -645,6 +645,8 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
 
       const leftWrapped = maybeWrapLatex(leftNode, left, prec, 'left', node.kind);
       const rightWrapped = maybeWrapLatex(rightNode, right, prec, 'right', node.kind);
+      const mulLeft = node.kind === 'Mul' && isSignedLiteralConst(leftNode) ? wrapParensLatex(leftWrapped) : leftWrapped;
+      const mulRight = node.kind === 'Mul' && isSignedLiteralConst(rightNode) ? wrapParensLatex(rightWrapped) : rightWrapped;
 
       switch (node.kind) {
         case 'Add': {
@@ -655,7 +657,7 @@ function nodeToLatex(node, parentPrec = 0, options = {}) {
         }
         case 'Mul': {
           // Use a thin space instead of `\\cdot` for readability.
-          return `${leftWrapped}\\,${rightWrapped}`;
+          return `${mulLeft}\\,${mulRight}`;
         }
         case 'Div': {
           // Prefer fractions for readability; they behave as an "atomic" group in TeX.

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1074,7 +1074,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v39</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v40</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -58,7 +58,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator by default; hide it once we have a first render.
 setCompileOverlayVisible(true, 'Loading…');
 
-const APP_VERSION = 39;
+const APP_VERSION = 40;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4077,7 +4077,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=39.0';
+  const SW_URL = './service-worker.js?sw=40.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '39.0';
+const CACHE_MINOR = '40.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Fixes MathJax rendering of negative constant bases in exponents and bumps the Reflex4You app major version.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cbcf32d-6ab2-4cd7-ac17-3e4ebdc669ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7cbcf32d-6ab2-4cd7-ac17-3e4ebdc669ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

