### PR TITLE
Function type parameters

### DIFF
--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -263,7 +263,7 @@ The input accepts succinct expressions with complex arithmetic, composition, and
 - **Bindings:**
   - `set name = value in body` introduces a **value** (evaluated once at the binding site; it can “capture” the current `z`).
   - `let name = expr in body` introduces a **function** (not evaluated until used; it always receives the ambient `z`).
-    - You can also define extra parameters: `let name(p1, p2, ...) = expr in body`.
+    - You can also define extra parameters: `let name(set p1, set p2, ...) = expr in body`.
     - `z` is reserved and cannot be used as a parameter name.
 
 Examples:
@@ -285,14 +285,14 @@ Reflex formulas are **functions of `z`**, so a `let` binding defines a reusable 
   - Use at a specific input: `f(expr)` (equivalently `f $ expr`).
 
 - **Multi-argument functions (extra params)**:
-  - Define: `let max(w) = if(z < w, w, z) in ...`
+  - Define: `let max(set w) = if(z < w, w, z) in ...`
   - Call with explicit arguments:
     - `max(a)` binds `w = a` and uses the current `z`.
     - `max(a, z0)` binds `w = a` and uses `z0` **instead of** the ambient `z` (the optional final argument overrides `z`).
   - If you reference a function that requires extra parameters without supplying them, it is a compile-time error.
 
 - **Passing functions to functions**:
-  - Mark a parameter as a function with `let` in the parameter list.
+  - Mark parameters explicitly with `set` (value) or `let` (function). If you omit the keyword, it is treated like `set`.
   - Example (numerical derivative):
 
 ```text
@@ -301,7 +301,7 @@ derivative(sin)
 ```
 
   - Function parameters can declare extra arguments by repeating a signature:
-    - `let apply1(let filter(w), w0) = filter(w0 + 1) in apply1(sin, 0)`
+    - `let apply1(let filter(set w), set w0) = filter(w0 + 1) in apply1(sin, 0)`
 
 - **Repeated composition (`$$`)** works inside `let` bodies as well:
   - `f $$ n` repeats `f` exactly `n` times (same as `oo(f, n)`).

--- a/apps/reflex4you/README.md
+++ b/apps/reflex4you/README.md
@@ -291,6 +291,18 @@ Reflex formulas are **functions of `z`**, so a `let` binding defines a reusable 
     - `max(a, z0)` binds `w = a` and uses `z0` **instead of** the ambient `z` (the optional final argument overrides `z`).
   - If you reference a function that requires extra parameters without supplying them, it is a compile-time error.
 
+- **Passing functions to functions**:
+  - Mark a parameter as a function with `let` in the parameter list.
+  - Example (numerical derivative):
+
+```text
+let derivative(let f) = (f(z + 0.001) - f(z)) / 0.001 in
+derivative(sin)
+```
+
+  - Function parameters can declare extra arguments by repeating a signature:
+    - `let apply1(let filter(w), w0) = filter(w0 + 1) in apply1(sin, 0)`
+
 - **Repeated composition (`$$`)** works inside `let` bodies as well:
   - `f $$ n` repeats `f` exactly `n` times (same as `oo(f, n)`).
   - Example:

--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -104,8 +104,52 @@ function attachIdentifierMeta(node, meta) {
   return node;
 }
 
-function createParamRef(name) {
-  return { kind: 'ParamRef', name };
+function createParamSpec(name, kind = 'value', args = []) {
+  return {
+    name: String(name || ''),
+    kind: kind === 'fn' ? 'fn' : 'value',
+    args: Array.isArray(args) ? args : [],
+  };
+}
+
+function normalizeParamSpecs(paramSpecs, legacyParams = null) {
+  if (Array.isArray(paramSpecs)) {
+    if (paramSpecs.length === 0) return [];
+    const first = paramSpecs[0];
+    if (first && typeof first === 'object' && typeof first.kind === 'string') {
+      return paramSpecs;
+    }
+  }
+  const params = Array.isArray(legacyParams)
+    ? legacyParams
+    : (Array.isArray(paramSpecs) ? paramSpecs : []);
+  return params.map((name) => createParamSpec(name, 'value', []));
+}
+
+function getLetParamSpecs(node) {
+  if (!node || typeof node !== 'object') return [];
+  return normalizeParamSpecs(node.paramSpecs, node.params);
+}
+
+function getValueParamNames(paramSpecs) {
+  return Array.isArray(paramSpecs)
+    ? paramSpecs.filter((spec) => spec && spec.kind !== 'fn').map((spec) => spec.name)
+    : [];
+}
+
+function createParamRef(paramOrName, paramSpec = null) {
+  let name = paramOrName;
+  let spec = paramSpec;
+  if (paramOrName && typeof paramOrName === 'object' && typeof paramOrName.name === 'string') {
+    name = paramOrName.name;
+    spec = paramOrName;
+  }
+  const node = { kind: 'ParamRef', name: String(name || '') };
+  if (spec && typeof spec === 'object' && typeof spec.kind === 'string') {
+    node.paramKind = spec.kind === 'fn' ? 'fn' : 'value';
+    node.paramSpec = spec;
+  }
+  return node;
 }
 
 function createIdentifier(name, meta = null) {
@@ -1741,6 +1785,24 @@ function resolveSetReferences(ast, input) {
   const letEnv = [];
   const paramEnv = [];
 
+  function buildParamEnvFrame(paramSpecs) {
+    const frame = new Map();
+    (Array.isArray(paramSpecs) ? paramSpecs : []).forEach((spec) => {
+      if (spec && typeof spec.name === 'string' && spec.name) {
+        frame.set(spec.name, spec);
+      }
+    });
+    return frame;
+  }
+
+  function findParamSpecForName(name) {
+    for (let i = paramEnv.length - 1; i >= 0; i -= 1) {
+      const spec = paramEnv[i].get(name);
+      if (spec) return spec;
+    }
+    return null;
+  }
+
   function findLetBindingForName(name) {
     for (let i = letEnv.length - 1; i >= 0; i -= 1) {
       if (letEnv[i].name === name) {
@@ -1759,7 +1821,8 @@ function resolveSetReferences(ast, input) {
         // `let name(params...) = value in body`
         // - `name` is in scope only for `body`
         // - nested `let` is handled by a separate top-level validation step; still traverse.
-        paramEnv.push(new Set(Array.isArray(node.params) ? node.params : []));
+        const paramSpecs = getLetParamSpecs(node);
+        paramEnv.push(buildParamEnvFrame(paramSpecs));
         const valueErr = visit(node.value, node, 'value');
         paramEnv.pop();
         if (valueErr) {
@@ -1782,15 +1845,14 @@ function resolveSetReferences(ast, input) {
       }
       case 'Identifier': {
         // Let-parameter references (first-order placeholders).
-        for (let i = paramEnv.length - 1; i >= 0; i -= 1) {
-          if (paramEnv[i].has(node.name)) {
-            const resolved = createParamRef(node.name);
-            resolved.span = node.span;
-            resolved.input = node.input;
-            resolved.__identifierMeta = node.__identifierMeta;
-            Object.assign(node, resolved);
-            return null;
-          }
+        const paramSpec = findParamSpecForName(node.name);
+        if (paramSpec) {
+          const resolved = createParamRef(paramSpec);
+          resolved.span = node.span;
+          resolved.input = node.input;
+          resolved.__identifierMeta = node.__identifierMeta;
+          Object.assign(node, resolved);
+          return null;
         }
 
         const binding = findBindingForName(setEnv, node.name);
@@ -1803,21 +1865,6 @@ function resolveSetReferences(ast, input) {
         }
         const letBinding = findLetBindingForName(node.name);
         if (letBinding) {
-          const paramCount = Array.isArray(letBinding.params) ? letBinding.params.length : 0;
-          if (paramCount > 0) {
-            const isCallCallee = parent && typeof parent === 'object' && parent.kind === 'Call' && key === 'callee';
-            if (!isCallCallee) {
-              const span = node.span ?? input.createSpan(0, 0);
-              return new ParseFailure({
-                ctor: 'Identifier',
-                message: `Function "${node.name}" requires ${paramCount} extra argument${paramCount === 1 ? '' : 's'}`,
-                severity: ParseSeverity.error,
-                expected: 'function call',
-                span,
-                input: span.input || input,
-              });
-            }
-          }
           // Keep the identifier node (so the renderer can still show the name),
           // but tag it so GPU lowering can resolve it later.
           node.__letBinding = letBinding;
@@ -1873,7 +1920,8 @@ function resolveSetReferences(ast, input) {
         const stepErr = visit(node.step, node, 'step');
         if (stepErr) return stepErr;
         const loopName = String(node.varName || '');
-        paramEnv.push(new Set(loopName ? [loopName] : []));
+        const loopSpec = loopName ? createParamSpec(loopName, 'value', []) : null;
+        paramEnv.push(buildParamEnvFrame(loopSpec ? [loopSpec] : []));
         const bodyErr = visit(node.body, node, 'body');
         paramEnv.pop();
         return bodyErr;
@@ -2039,6 +2087,288 @@ function validateLetBindingsTopLevelOnly(ast, input) {
     });
   }
   return null;
+}
+
+function paramSpecSignatureToText(specs) {
+  if (!Array.isArray(specs) || specs.length === 0) {
+    return '()';
+  }
+  const rendered = specs.map((spec) => {
+    if (!spec || typeof spec !== 'object') return '?';
+    if (spec.kind !== 'fn') {
+      return String(spec.name || '?');
+    }
+    const nested = paramSpecSignatureToText(spec.args);
+    const name = String(spec.name || '?');
+    return `let ${name}${nested === '()' ? '' : nested}`;
+  });
+  return `(${rendered.join(', ')})`;
+}
+
+function paramSpecsCompatible(expected, actual) {
+  const expList = Array.isArray(expected) ? expected : [];
+  const actList = Array.isArray(actual) ? actual : [];
+  if (expList.length !== actList.length) return false;
+  for (let i = 0; i < expList.length; i += 1) {
+    const exp = expList[i];
+    const act = actList[i];
+    if (!exp || !act) return false;
+    const expKind = exp.kind === 'fn' ? 'fn' : 'value';
+    const actKind = act.kind === 'fn' ? 'fn' : 'value';
+    if (expKind !== actKind) return false;
+    if (expKind === 'fn' && !paramSpecsCompatible(exp.args, act.args)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function validateFunctionParamUsage(ast, input) {
+  const paramEnv = [];
+  const letStack = [];
+
+  function buildParamEnvFrame(paramSpecs) {
+    const frame = new Map();
+    (Array.isArray(paramSpecs) ? paramSpecs : []).forEach((spec) => {
+      if (spec && typeof spec.name === 'string' && spec.name) {
+        frame.set(spec.name, spec);
+      }
+    });
+    return frame;
+  }
+
+  function findParamSpecForName(name) {
+    for (let i = paramEnv.length - 1; i >= 0; i -= 1) {
+      const spec = paramEnv[i].get(name);
+      if (spec) return spec;
+    }
+    return null;
+  }
+
+  function signatureForNode(node) {
+    if (!node || typeof node !== 'object') return null;
+    if (node.kind === 'ParamRef') {
+      const spec = node.paramSpec || findParamSpecForName(node.name);
+      if (!spec || spec.kind !== 'fn') return null;
+      return spec.args || [];
+    }
+    if (node.kind === 'Identifier') {
+      const binding = node.__letBinding || resolveLetBindingByName(node.name, letStack);
+      if (!binding) return null;
+      return getLetParamSpecs(binding);
+    }
+    if (node.__functionLiteral) {
+      return [];
+    }
+    return null;
+  }
+
+  function failureForSignatureMismatch(node, paramName, expectedSpecs) {
+    const span = node.span ?? input.createSpan(0, 0);
+    const expectedText = paramSpecSignatureToText(expectedSpecs);
+    return new ParseFailure({
+      ctor: 'Call',
+      message: `Argument for parameter "${paramName}" must match signature ${expectedText}`,
+      severity: ParseSeverity.error,
+      expected: `signature ${expectedText}`,
+      span,
+      input: span.input || input,
+    });
+  }
+
+  function validateExpr(node, expectedParamSpec = null) {
+    if (!node || typeof node !== 'object') return null;
+
+    if (expectedParamSpec) {
+      if (expectedParamSpec.kind !== 'fn') {
+        return validateExpr(node, null);
+      }
+      const expectedSpecs = Array.isArray(expectedParamSpec.args) ? expectedParamSpec.args : [];
+      const actualSpecs = signatureForNode(node);
+      if (expectedSpecs.length > 0) {
+        if (!actualSpecs || !paramSpecsCompatible(expectedSpecs, actualSpecs)) {
+          return failureForSignatureMismatch(node, expectedParamSpec.name, expectedSpecs);
+        }
+        return null;
+      }
+      if (actualSpecs && !paramSpecsCompatible(expectedSpecs, actualSpecs)) {
+        return failureForSignatureMismatch(node, expectedParamSpec.name, expectedSpecs);
+      }
+      return validateExpr(node, null);
+    }
+
+    const actualSpecs = signatureForNode(node);
+    if (actualSpecs && actualSpecs.length > 0) {
+      const span = node.span ?? input.createSpan(0, 0);
+      return new ParseFailure({
+        ctor: 'Identifier',
+        message: `Function value with ${actualSpecs.length} parameter${actualSpecs.length === 1 ? '' : 's'} must be called or passed as a function argument`,
+        severity: ParseSeverity.error,
+        expected: 'function call',
+        span,
+        input: span.input || input,
+      });
+    }
+
+    switch (node.kind) {
+      case 'LetBinding': {
+        const paramSpecs = getLetParamSpecs(node);
+        paramEnv.push(buildParamEnvFrame(paramSpecs));
+        const valueErr = validateExpr(node.value, null);
+        paramEnv.pop();
+        if (valueErr) return valueErr;
+        letStack.push(node);
+        const bodyErr = validateExpr(node.body, null);
+        letStack.pop();
+        return bodyErr;
+      }
+      case 'SetBinding': {
+        const valueErr = validateExpr(node.value, null);
+        if (valueErr) return valueErr;
+        return validateExpr(node.body, null);
+      }
+      case 'Call': {
+        const calleeSpecs = signatureForNode(node.callee);
+        const args = Array.isArray(node.args) ? node.args : [];
+        if (calleeSpecs) {
+          const k = calleeSpecs.length;
+          if (!(args.length === k || args.length === k + 1)) {
+            const span = node.span ?? input.createSpan(0, 0);
+            return new ParseFailure({
+              ctor: 'Call',
+              message: `Function call expects ${k} or ${k + 1} arguments, got ${args.length}`,
+              severity: ParseSeverity.error,
+              expected: `${k} or ${k + 1} arguments`,
+              span,
+              input: span.input || input,
+            });
+          }
+          for (let i = 0; i < k; i += 1) {
+            const argErr = validateExpr(args[i], calleeSpecs[i]);
+            if (argErr) return argErr;
+          }
+          if (args.length === k + 1) {
+            const zErr = validateExpr(args[args.length - 1], null);
+            if (zErr) return zErr;
+          }
+          return null;
+        }
+        if (args.length !== 1) {
+          const span = node.span ?? input.createSpan(0, 0);
+          return new ParseFailure({
+            ctor: 'Call',
+            message: `Only unary calls are supported here (got ${args.length} args)`,
+            severity: ParseSeverity.error,
+            expected: 'one argument',
+            span,
+            input: span.input || input,
+          });
+        }
+        const calleeErr = validateExpr(node.callee, null);
+        if (calleeErr) return calleeErr;
+        return validateExpr(args[0], null);
+      }
+      case 'Pow':
+        return validateExpr(node.base, null);
+      case 'PowExpr': {
+        const baseErr = validateExpr(node.base, null);
+        if (baseErr) return baseErr;
+        return validateExpr(node.exponent, null);
+      }
+      case 'Exp':
+      case 'Sin':
+      case 'Cos':
+      case 'Tan':
+      case 'Atan':
+      case 'Asin':
+      case 'Acos':
+      case 'Gamma':
+      case 'Fact':
+      case 'Abs':
+      case 'Abs2':
+      case 'Floor':
+      case 'Conjugate':
+      case 'IsNaN':
+        return validateExpr(node.value, null);
+      case 'Ln':
+      case 'Arg': {
+        const valueErr = validateExpr(node.value, null);
+        if (valueErr) return valueErr;
+        if (node.branch) return validateExpr(node.branch, null);
+        return null;
+      }
+      case 'Sub':
+      case 'Mul':
+      case 'Op':
+      case 'Add':
+      case 'Div':
+      case 'LessThan':
+      case 'GreaterThan':
+      case 'LessThanOrEqual':
+      case 'GreaterThanOrEqual':
+      case 'Equal':
+      case 'LogicalAnd':
+      case 'LogicalOr': {
+        const leftErr = validateExpr(node.left, null);
+        if (leftErr) return leftErr;
+        return validateExpr(node.right, null);
+      }
+      case 'Compose': {
+        const gErr = validateExpr(node.g, null);
+        if (gErr) return gErr;
+        return validateExpr(node.f, null);
+      }
+      case 'ComposeMultiple': {
+        const baseErr = validateExpr(node.base, null);
+        if (baseErr) return baseErr;
+        if (node.countExpression) return validateExpr(node.countExpression, null);
+        return null;
+      }
+      case 'If': {
+        const condErr = validateExpr(node.condition, null);
+        if (condErr) return condErr;
+        const thenErr = validateExpr(node.thenBranch, null);
+        if (thenErr) return thenErr;
+        return validateExpr(node.elseBranch, null);
+      }
+      case 'IfNaN': {
+        const valueErr = validateExpr(node.value, null);
+        if (valueErr) return valueErr;
+        return validateExpr(node.fallback, null);
+      }
+      case 'Repeat': {
+        if (node.countExpression) {
+          const countErr = validateExpr(node.countExpression, null);
+          if (countErr) return countErr;
+        }
+        const initExprs = Array.isArray(node.fromExpressions) ? node.fromExpressions : [];
+        for (let i = 0; i < initExprs.length; i += 1) {
+          const initErr = validateExpr(initExprs[i], null);
+          if (initErr) return initErr;
+        }
+        return null;
+      }
+      case 'Sum':
+      case 'Prod': {
+        const minErr = validateExpr(node.min, null);
+        if (minErr) return minErr;
+        const maxErr = validateExpr(node.max, null);
+        if (maxErr) return maxErr;
+        const stepErr = validateExpr(node.step, null);
+        if (stepErr) return stepErr;
+        const loopName = String(node.varName || '');
+        const loopSpec = loopName ? createParamSpec(loopName, 'value', []) : null;
+        paramEnv.push(buildParamEnvFrame(loopSpec ? [loopSpec] : []));
+        const bodyErr = validateExpr(node.body, null);
+        paramEnv.pop();
+        return bodyErr;
+      }
+      default:
+        return null;
+    }
+  }
+
+  return validateExpr(ast, null);
 }
 
 function findBindingForName(env, name) {
@@ -2475,7 +2805,18 @@ function validateRepeatExpressions(ast, parseOptions, input) {
               input: span.input || input,
             });
           }
-          const arity = Array.isArray(binding.params) ? binding.params.length : 0;
+          const paramSpecs = getLetParamSpecs(binding);
+          const arity = paramSpecs.length;
+          if (paramSpecs.some((spec) => spec && spec.kind === 'fn')) {
+            return new ParseFailure({
+              ctor: 'RepeatBinding',
+              message: `repeat step function "${name}" cannot take function-typed parameters`,
+              severity: ParseSeverity.error,
+              expected: 'value-typed parameters',
+              span: binding.span ?? span,
+              input: (binding.span?.input ?? span.input) || input,
+            });
+          }
           if (arity !== k + 1) {
             return new ParseFailure({
               ctor: 'RepeatBinding',
@@ -3668,6 +4009,9 @@ const setBindingParser = createParser('SetBinding', (input) => {
 const letKeyword = keywordLiteral('let', { ctor: 'LetKeyword' });
 const letEqualsLiteral = wsLiteral('=', { ctor: 'LetEquals' });
 
+let letParamSpecParser;
+const letParamSpecRef = lazy(() => letParamSpecParser, { ctor: 'LetParamSpecRef' });
+
 const letParamListParser = createParser('LetParamList', (input) => {
   const open = wsLiteral('(', { ctor: 'LetParamOpen' }).runNormalized(input);
   if (!open.ok) {
@@ -3688,7 +4032,7 @@ const letParamListParser = createParser('LetParamList', (input) => {
     return closeImmediate;
   }
 
-  const first = bindingIdentifierParser.runNormalized(open.next);
+  const first = letParamSpecRef.runNormalized(open.next);
   if (!first.ok) {
     return first;
   }
@@ -3702,7 +4046,7 @@ const letParamListParser = createParser('LetParamList', (input) => {
       }
       break;
     }
-    const nextParam = bindingIdentifierParser.runNormalized(comma.next);
+    const nextParam = letParamSpecRef.runNormalized(comma.next);
     if (!nextParam.ok) {
       return nextParam;
     }
@@ -3722,6 +4066,46 @@ const letParamListParser = createParser('LetParamList', (input) => {
   });
 });
 
+letParamSpecParser = createParser('LetParamSpec', (input) => {
+  const letMarker = letKeyword.runNormalized(input);
+  if (letMarker.ok) {
+    const nameResult = bindingIdentifierParser.runNormalized(letMarker.next);
+    if (!nameResult.ok) {
+      return nameResult;
+    }
+    let cursor = nameResult.next;
+    let nestedParams = [];
+    const nestedList = letParamListParser.runNormalized(cursor);
+    if (nestedList.ok) {
+      nestedParams = nestedList.value;
+      cursor = nestedList.next;
+    } else if (nestedList.severity === ParseSeverity.error) {
+      return nestedList;
+    }
+    const span = spanBetween(input, cursor);
+    return new ParseSuccess({
+      ctor: 'LetParamSpec',
+      value: createParamSpec(nameResult.value, 'fn', nestedParams),
+      span,
+      next: cursor,
+    });
+  }
+  if (letMarker.severity === ParseSeverity.error) {
+    return letMarker;
+  }
+
+  const nameResult = bindingIdentifierParser.runNormalized(input);
+  if (!nameResult.ok) {
+    return nameResult;
+  }
+  return new ParseSuccess({
+    ctor: 'LetParamSpec',
+    value: createParamSpec(nameResult.value, 'value', []),
+    span: nameResult.span,
+    next: nameResult.next,
+  });
+});
+
 const letBindingParser = createParser('LetBinding', (input) => {
   const keyword = letKeyword.runNormalized(input);
   if (!keyword.ok) {
@@ -3731,11 +4115,11 @@ const letBindingParser = createParser('LetBinding', (input) => {
   if (!nameResult.ok) {
     return nameResult;
   }
-  let params = [];
+  let paramSpecs = [];
   let cursor = nameResult.next;
   const paramList = letParamListParser.runNormalized(cursor);
   if (paramList.ok) {
-    params = paramList.value;
+    paramSpecs = paramList.value;
     cursor = paramList.next;
   } else if (paramList.severity === ParseSeverity.error) {
     return paramList;
@@ -3758,10 +4142,12 @@ const letBindingParser = createParser('LetBinding', (input) => {
     return bodyResult;
   }
   const span = spanBetween(input, bodyResult.next);
+  const valueParams = getValueParamNames(paramSpecs);
   const value = {
     kind: 'LetBinding',
     name: nameResult.value,
-    params,
+    params: valueParams,
+    paramSpecs,
     value: valueResult.value,
     body: bodyResult.value,
     span,
@@ -3834,6 +4220,10 @@ export function parseFormulaInput(input, options = {}) {
   const resolveError = resolveSetReferences(parsed.value, normalized);
   if (resolveError instanceof ParseFailure) {
     return resolveError;
+  }
+  const signatureValidated = validateFunctionParamUsage(parsed.value, normalized);
+  if (signatureValidated instanceof ParseFailure) {
+    return signatureValidated;
   }
   const repeatResolved = resolveRepeatPlaceholders(parsed.value, parseOptions, normalized);
   if (repeatResolved instanceof ParseFailure) {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -810,7 +810,7 @@ test('missing "in" after let binding does not backtrack', () => {
 
 test('multi-argument let bindings parse and call with extra args (z remains ambient)', () => {
   const source = `
-let customif(thn, els) = if(z, thn, els) in
+let customif(set thn, set els) = if(z, thn, els) in
 customif(sin, cos)
 `.trim();
   const result = parseFormulaInput(source);
@@ -819,6 +819,8 @@ customif(sin, cos)
   assert.equal(ast.kind, 'LetBinding');
   assert.equal(ast.name, 'customif');
   assert.deepEqual(ast.params, ['thn', 'els']);
+  assert.equal(ast.paramSpecs[0].prefix, 'set');
+  assert.equal(ast.paramSpecs[1].prefix, 'set');
   assert.equal(ast.body.kind, 'Call');
   assert.equal(ast.body.callee.kind, 'Identifier');
   assert.equal(ast.body.callee.name, 'customif');
@@ -829,7 +831,7 @@ customif(sin, cos)
 
 test('multi-argument let calls can override z with a final argument (z-last)', () => {
   const source = `
-let customif(thn, els) = if(z, thn, els) in
+let customif(set thn, set els) = if(z, thn, els) in
 customif(sin, cos, z)
 `.trim();
   const result = parseFormulaInput(source);
@@ -842,14 +844,14 @@ customif(sin, cos, z)
 });
 
 test('multi-argument let functions are not first-class values (must be called)', () => {
-  const result = parseFormulaInput('let max(w) = if(z < w, w, z) in max');
+  const result = parseFormulaInput('let max(set w) = if(z < w, w, z) in max');
   assert.equal(result.ok, false);
   assert.match(result.message, /must be called or passed as a function argument/i);
 });
 
 test('function-typed let params accept expression arguments', () => {
   const source = `
-let min(w) = if(w < z, w, z) in
+let min(set w) = if(w < z, w, z) in
 let apply1(let filter) = z - 3 $ filter $ z + 3 in
 apply1(min(0))
 `.trim();
@@ -866,8 +868,8 @@ apply1(min(0))
 
 test('function-typed let params accept matching signatures', () => {
   const source = `
-let min(w) = if(w < z, w, z) in
-let apply1(let filter(w), w0) = z - 3 $ filter(w0 + 1) $ z + 3 in
+let min(set w) = if(w < z, w, z) in
+let apply1(let filter(set w), set w0) = z - 3 $ filter(w0 + 1) $ z + 3 in
 apply1(min, 0.2)
 `.trim();
   const result = parseFormulaInput(source);
@@ -883,7 +885,7 @@ apply1(min, 0.2)
 test('nested function-typed param signatures parse', () => {
   const source = `
 let apply1(let f) = f $ (z + 1) in
-let apply2(let apply1(let apply0), let apply0, c) = apply1(apply0) + c in
+let apply2(let apply1(let apply0), let apply0, set c) = apply1(apply0) + c in
 apply2(apply1, sin, 2)
 `.trim();
   const result = parseFormulaInput(source);
@@ -898,8 +900,8 @@ apply2(apply1, sin, 2)
 
 test('function-typed params reject mismatched signatures', () => {
   const source = `
-let min(w) = if(w < z, w, z) in
-let apply1(let filter(w), w0) = filter(w0 + 1) in
+let min(set w) = if(w < z, w, z) in
+let apply1(let filter(set w), set w0) = filter(w0 + 1) in
 apply1(min(0), 2)
 `.trim();
   const result = parseFormulaInput(source);

--- a/apps/reflex4you/core-engine.mjs
+++ b/apps/reflex4you/core-engine.mjs
@@ -1308,11 +1308,12 @@ export function SetRef(name, binding = null) {
   return { kind: "SetRef", name, binding };
 }
 
-function createParamSpec(name, kind = 'value', args = []) {
+function createParamSpec(name, kind = 'value', args = [], prefix = null) {
   return {
     name: String(name || ''),
     kind: kind === 'fn' ? 'fn' : 'value',
     args: Array.isArray(args) ? args : [],
+    prefix: prefix === 'set' || prefix === 'let' ? prefix : null,
   };
 }
 
@@ -1327,7 +1328,7 @@ function normalizeParamSpecs(paramSpecs, legacyParams = null) {
   const params = Array.isArray(legacyParams)
     ? legacyParams
     : (Array.isArray(paramSpecs) ? paramSpecs : []);
-  return params.map((name) => createParamSpec(name, 'value', []));
+  return params.map((name) => createParamSpec(name, 'value', [], null));
 }
 
 function getLetParamSpecs(node) {

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -450,7 +450,7 @@ test('function-param lowering preserves evaluation and removes higher-order para
     {
       name: 'arity-0 function param with expression argument',
       source: `
-let min(w) = if(w < z, w, z) in
+let min(set w) = if(w < z, w, z) in
 let apply1(let filter) = z - 3 $ filter $ z + 3 in
 apply1(min(0))
 `.trim(),
@@ -459,8 +459,8 @@ apply1(min(0))
     {
       name: 'arity-1 function param with function identifier',
       source: `
-let min(w) = if(w < z, w, z) in
-let apply1(let filter(w), w0) = z - 3 $ filter(w0 + 1) $ z + 3 in
+let min(set w) = if(w < z, w, z) in
+let apply1(let filter(set w), set w0) = z - 3 $ filter(w0 + 1) $ z + 3 in
 apply1(min, 0.2)
 `.trim(),
       zValues: [{ re: -1, im: 0 }, { re: 1.5, im: 0 }],
@@ -493,9 +493,9 @@ derivative(sin)
     {
       name: 'derivative along parameter function',
       source: `
-let derivativeX(let f(w), w) = (f(w + 0.001) - f(w)) / 0.001 in
-let derivativeY(let f(w), w) = (f(w, z + 0.001) - f(w, z)) / 0.001 in
-let s(w) = sin(w) * z in
+let derivativeX(let f(set w), set w) = (f(w + 0.001) - f(w)) / 0.001 in
+let derivativeY(let f(set w), set w) = (f(w, z + 0.001) - f(w, z)) / 0.001 in
+let s(set w) = sin(w) * z in
 derivativeX(s, 0) + derivativeY(s, z, 0)
 `.trim(),
       zValues: [{ re: -0.4, im: 0 }, { re: 0.7, im: 0 }],
@@ -503,7 +503,7 @@ derivativeX(s, 0) + derivativeY(s, z, 0)
     {
       name: 'integral of sin (finite sum)',
       source: `
-let integral(let f, start) =
+let integral(let f, set start) =
   set N = 100 in
   set w = (z - start) / N in
   sum(set x0 = f(start + n * w) in x0 * w, n, 0, N)

--- a/apps/reflex4you/core-engine.test.mjs
+++ b/apps/reflex4you/core-engine.test.mjs
@@ -163,6 +163,17 @@ function evaluateAstComplex(root, { z = { re: 0, im: 0 } } = {}) {
         }
         return v;
       }
+      case 'Identifier': {
+        const closure = lookupLet(node.name, localLetEnv);
+        if (!closure) {
+          throw new Error(`Unknown function: ${node.name}`);
+        }
+        const specLen = Array.isArray(closure.paramSpecs) ? closure.paramSpecs.length : 0;
+        if (specLen > 0) {
+          throw new Error(`Identifier "${node.name}" with ${specLen} args must be called`);
+        }
+        return applyFunctionValue(closure, [], zLocal);
+      }
       case 'SetRef': {
         const v = localSetEnv.get(node.binding);
         if (!v) throw new Error(`Unbound SetRef: ${node.name}`);

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1317,7 +1317,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=40.0';
+    const SW_URL = './service-worker.js?sw=40.1';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=40.0';
+  const SW_URL = './service-worker.js?sw=40.1';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-renderer.mjs
+++ b/apps/reflex4you/formula-renderer.mjs
@@ -198,11 +198,15 @@ function paramSpecToLatex(spec) {
     return escapeLatexIdentifier(String(spec || '?'));
   }
   const name = latexIdentifierWithMetadata(spec.name || '?', null);
+  const prefix = spec.prefix === 'set' || spec.prefix === 'let'
+    ? spec.prefix
+    : (spec.kind === 'fn' ? 'let' : null);
   if (spec.kind !== 'fn') {
-    return name;
+    return prefix ? `\\mathrm{${prefix}}\\;${name}` : name;
   }
   const nested = paramSpecListToLatex(spec.args);
-  return `\\mathrm{let}\\;${name}${nested}`;
+  const prefixText = prefix ? `\\mathrm{${prefix}}\\;` : '';
+  return `${prefixText}${name}${nested}`;
 }
 
 function paramSpecListToLatex(paramSpecs) {

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -4077,7 +4077,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=40.0';
+  const SW_URL = './service-worker.js?sw=40.1';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '40.0';
+const CACHE_MINOR = '40.1';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Adds support for function-typed `let` parameters with nested signatures and implements a GPU lowering pass to specialize them for GLSL compatibility.

This change addresses the limitation where `let` arguments were always evaluated to scalars, preventing the passing of functions. It introduces a new syntax (`let name(params)`) to explicitly declare function parameters. A new AST validation pass ensures correct usage. For GPU compilation, a lowering pass transforms calls to `let` bindings with function parameters by inlining the argument expressions into the `let` body, creating specialized `let` bindings that are compatible with GLSL, which does not support higher-order functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-45db5d98-2627-40e6-b84c-568b737a9393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45db5d98-2627-40e6-b84c-568b737a9393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces higher‑order functions in the formula language and makes them GPU‑compatible via specialization.
> 
> - **Language/Parser:** Add param specs (`set`/`let`) with nested signatures; resolve identifiers to `ParamRef` with kind; parse/pretty-print param lists; reject function‑typed params in `repeat`; new arity/signature checks.
> - **Validation:** New pass `validateFunctionParamUsage` to enforce calling/argument signatures and errors when functions are used as values improperly.
> - **Engine/GPU:** Add lowering pass to specialize calls with function params into first‑order `let`s; export/update `prepareAstForGpu`; forbid unresolved higher‑order funcs before GLSL.
> - **Renderer:** LaTeX output shows `let` parameter lists (including prefixes/signatures).
> - **Tests:** New parser/engine tests for function params, nested signatures, lowering equivalence, and GLSL generation.
> - **Docs:** README documents `let` param annotations and function arguments examples.
> - **PWA:** Bump service worker/cache version to `40.1` across pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7749a43722faf04ff74d2a9722bfd54a1ca8b616. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->