### PR TITLE
Black50 color scheme options

### DIFF
--- a/apps/reflex4you/formula.html
+++ b/apps/reflex4you/formula.html
@@ -332,10 +332,11 @@
           <div class="controls__field">
             <span class="controls__label">Canvas background (RRGGBBAA)</span>
             <input id="bghex" class="controls__input" type="text" value="ffffff80" spellcheck="false" inputmode="text" aria-label="Canvas background in RRGGBBAA hex" />
-            <button class="preset" type="button" data-bghex="ffffff80">white50</button>
-            <button class="preset" type="button" data-bghex="1e3a8aff">blue</button>
-            <button class="preset" type="button" data-bghex="000000ff">black</button>
-            <button class="preset" type="button" data-bghex="00000000">transparent</button>
+            <button class="preset" type="button" data-bghex="ffffff80" data-fghex="000000ff">white50</button>
+            <button class="preset" type="button" data-bghex="00000080" data-fghex="ffffffff">black50</button>
+            <button class="preset" type="button" data-bghex="1e3a8aff" data-fghex="000000ff">blue</button>
+            <button class="preset" type="button" data-bghex="000000ff" data-fghex="000000ff">black</button>
+            <button class="preset" type="button" data-bghex="00000000" data-fghex="000000ff">transparent</button>
           </div>
           <button id="download-png" class="btn" type="button" disabled>Download PNG</button>
         </div>


### PR DESCRIPTION
Add `black50` color scheme with foreground color control and reorder presets to prioritize `white50` and `black50`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c15880d8-acf8-4475-9df1-3fcbd3f0eb66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c15880d8-acf8-4475-9df1-3fcbd3f0eb66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable foreground color for canvas rendering and updates presets.
> 
> - Adds `foregroundHex` flow: stores current value in `formula-page.mjs`, passes to `renderFormulaToCanvas`, auto-syncs with background via preset map, and updates on input/preset clicks
> - Renderer (`formula-renderer.mjs`): resolves default/overridden foreground, uses it in fallback text draw and forces SVG `color:` style; bumps `FORMULA_RENDERER_BUILD_ID`
> - HTML (`formula.html`): preset buttons now include `data-fghex`; adds/reorders presets including `black50`; keeps default background `ffffff80`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93d235916b57e259c5b32a69c882d09c2d3f8030. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->