### PR TITLE
Parse error navigation

### DIFF
--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1317,7 +1317,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=41.0';
+    const SW_URL = './service-worker.js?sw=42.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-compile-worker.mjs
+++ b/apps/reflex4you/formula-compile-worker.mjs
@@ -1,5 +1,5 @@
 import { parseFormulaInput } from './arithmetic-parser.mjs';
-import { formatCaretIndicator } from './parse-error-format.mjs';
+import { formatCaretIndicator, getCaretSelection } from './parse-error-format.mjs';
 import { compileFormulaForGpu } from './core-engine.mjs';
 
 function nowMs() {
@@ -22,10 +22,12 @@ self.onmessage = (event) => {
     const result = parseFormulaInput(source, { fingerValues });
     parseMs = nowMs() - parseStart;
     if (!result.ok) {
+      const caretSelection = getCaretSelection(source, result);
       self.postMessage({
         id,
         ok: false,
         caretMessage: formatCaretIndicator(source, result),
+        caretSelection,
         timings: { workerParseMs: parseMs },
       });
       return;

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -12,7 +12,7 @@ import {
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=41.0';
+  const SW_URL = './service-worker.js?sw=42.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula.html
+++ b/apps/reflex4you/formula.html
@@ -168,6 +168,10 @@
       max-height: 42vh;
     }
 
+    .error[data-error-kind="parse"] {
+      cursor: pointer;
+    }
+
     .formula {
       padding: 0;
       border-radius: 14px;

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -93,6 +93,10 @@
       z-index: 20;
     }
 
+    #error[data-error-kind="parse"] {
+      cursor: pointer;
+    }
+
     #error[data-error-severity="fatal"] {
       pointer-events: auto;
       user-select: text;

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1079,7 +1079,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v41</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v42</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -12,7 +12,7 @@ import {
 import { formulaAstToLatex, renderLatexToCanvas } from './formula-renderer.mjs';
 import { visitAst } from './ast-utils.mjs';
 import { parseFormulaInput } from './arithmetic-parser.mjs';
-import { formatCaretIndicator } from './parse-error-format.mjs';
+import { formatCaretIndicator, getCaretSelection } from './parse-error-format.mjs';
 import {
   FORMULA_PARAM,
   FORMULA_B64_PARAM,
@@ -44,6 +44,7 @@ const compileOverlayText = document.getElementById('compile-overlay-text');
 const rootElement = typeof document !== 'undefined' ? document.documentElement : null;
 
 let fatalErrorActive = false;
+let parseErrorSelection = null;
 
 const COMPILE_OVERLAY_TICK_MS = 240;
 const COMPILE_STATUS_DELAY_MS = 1000;
@@ -156,6 +157,7 @@ function showCompileStatusMessage(message) {
   if (fatalErrorActive || !errorDiv) {
     return;
   }
+  setParseErrorSelection(null);
   const severity = errorDiv.getAttribute('data-error-severity');
   if (severity && severity !== 'status') {
     return;
@@ -2341,11 +2343,86 @@ function handleTrackballChange(su2) {
   }
 }
 
-function showError(msg) {
+function setParseErrorSelection(selection) {
+  if (!selection || !Number.isFinite(selection.start) || !formulaTextarea) {
+    parseErrorSelection = null;
+    if (errorDiv) {
+      errorDiv.removeAttribute('data-error-kind');
+      errorDiv.removeAttribute('title');
+    }
+    return;
+  }
+  const start = Math.max(0, selection.start);
+  const end = Number.isFinite(selection.end) ? Math.max(start, selection.end) : start;
+  parseErrorSelection = { start, end };
+  if (errorDiv) {
+    errorDiv.setAttribute('data-error-kind', 'parse');
+    errorDiv.title = 'Click to jump to error';
+  }
+}
+
+function scrollTextareaToSelection(textarea, selectionStart) {
+  if (!textarea || typeof window === 'undefined') {
+    return;
+  }
+  const value = textarea.value || '';
+  const lineIndex = value.slice(0, selectionStart).split('\n').length - 1;
+  let lineHeight = null;
+  try {
+    const style = window.getComputedStyle(textarea);
+    lineHeight = parseFloat(style.lineHeight);
+    if (!Number.isFinite(lineHeight)) {
+      const fontSize = parseFloat(style.fontSize);
+      lineHeight = Number.isFinite(fontSize) ? fontSize * 1.35 : null;
+    }
+  } catch (_) {
+    lineHeight = null;
+  }
+  const targetTop = Number.isFinite(lineHeight)
+    ? Math.max(0, lineIndex * lineHeight - textarea.clientHeight * 0.3)
+    : null;
+  if (Number.isFinite(targetTop)) {
+    textarea.scrollTop = targetTop;
+  }
+}
+
+function focusFormulaSelection(selection) {
+  if (!formulaTextarea || !selection) {
+    return;
+  }
+  const valueLength = formulaTextarea.value.length;
+  const start = Math.max(0, Math.min(selection.start, valueLength));
+  const end = Math.max(start, Math.min(selection.end, valueLength));
+  formulaTextarea.focus();
+  try {
+    formulaTextarea.setSelectionRange(start, end);
+  } catch (_) {
+    // ignore
+  }
+  scrollTextareaToSelection(formulaTextarea, start);
+}
+
+function handleParseErrorClick(event) {
+  if (fatalErrorActive || !parseErrorSelection || !formulaTextarea) {
+    return;
+  }
+  if (event?.target?.closest) {
+    const ignore = event.target.closest('button, a, input, textarea, select, .error-actions');
+    if (ignore) {
+      return;
+    }
+  }
+  event?.preventDefault?.();
+  event?.stopPropagation?.();
+  focusFormulaSelection(parseErrorSelection);
+}
+
+function showError(msg, { parseSelection } = {}) {
   if (fatalErrorActive) {
     return;
   }
   clearCompileOverlayPhase();
+  setParseErrorSelection(parseSelection);
   errorDiv.setAttribute('data-error-severity', 'error');
   try {
     errorDiv.innerHTML = '';
@@ -2359,6 +2436,7 @@ function showError(msg) {
 function showFatalError(msg) {
   clearCompileOverlayPhase();
   fatalErrorActive = true;
+  setParseErrorSelection(null);
   errorDiv.setAttribute('data-error-severity', 'fatal');
   try {
     errorDiv.innerHTML = '';
@@ -2424,6 +2502,7 @@ function clearError() {
     return;
   }
   compileStatusVisible = false;
+  setParseErrorSelection(null);
   errorDiv.removeAttribute('data-error-severity');
   errorDiv.style.display = 'none';
   try {
@@ -2431,6 +2510,10 @@ function clearError() {
   } catch (_) {
     errorDiv.textContent = '';
   }
+}
+
+if (errorDiv) {
+  errorDiv.addEventListener('click', handleParseErrorClick);
 }
 
 function handleRendererInitializationFailure(error) {
@@ -2554,7 +2637,8 @@ function maybeRecoverFromWebglContextLoss() {
 }
 
 function showParseError(source, failure) {
-  showError(formatCaretIndicator(source, failure));
+  const parseSelection = getCaretSelection(source, failure);
+  showError(formatCaretIndicator(source, failure), { parseSelection });
 }
 
 // =========================
@@ -2598,7 +2682,9 @@ function ensureFormulaCompileWorker() {
     }
 
     if (!data.ok) {
-      showError(String(data.caretMessage || 'Unable to parse formula.'));
+      showError(String(data.caretMessage || 'Unable to parse formula.'), {
+        parseSelection: data.caretSelection,
+      });
       setCompileOverlayVisible(false);
       return;
     }

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -269,7 +269,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator only if it hangs > 1s.
 setCompileOverlayPhase('Loading…', { resetStart: true });
 
-const APP_VERSION = 41;
+const APP_VERSION = 42;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4524,7 +4524,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=41.0';
+  const SW_URL = './service-worker.js?sw=42.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/parse-error-format.mjs
+++ b/apps/reflex4you/parse-error-format.mjs
@@ -19,3 +19,22 @@ export function formatCaretIndicator(source, failure) {
 
   return `${line}\n${caretLine}\n${message}`;
 }
+
+export function getCaretSelection(source, failure) {
+  if (!failure?.span) return null;
+  const displaySource = String(source ?? '');
+  const origin = failure?.span?.input?.start ?? 0;
+  const rawStart = failure?.span?.start - origin;
+  const rawEnd = failure?.span?.end - origin;
+  if (!Number.isFinite(rawStart) || !Number.isFinite(rawEnd)) {
+    return null;
+  }
+  const maxLen = displaySource.length;
+  const start = Math.max(0, Math.min(rawStart, maxLen));
+  const endRaw = Math.max(0, Math.min(rawEnd, maxLen));
+  let end = endRaw;
+  if (end <= start && maxLen > 0) {
+    end = Math.min(start + 1, maxLen);
+  }
+  return { start, end };
+}

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '41.0';
+const CACHE_MINOR = '42.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Add clickable parse errors to scroll and select formula text.

This improves user experience by allowing quick navigation to the exact location of a parse error in the formula input field on both the main and formula pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-08d993ca-548c-4357-b252-082e20a8b540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08d993ca-548c-4357-b252-082e20a8b540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

