### PR TITLE
Api preview formula64

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -48,7 +48,7 @@ You can test this on https://hoppscotch.io/, just select POST, select body, cont
   "duration": "6s",
   "solos": ["D1", "D2"],
   "edit": true,
-  "compress": true,
+  "compress": false,
   "includeFormulaParam": false,
   "validate": true,
   "compile": false
@@ -61,7 +61,7 @@ You can test this on https://hoppscotch.io/, just select POST, select body, cont
   strings (`a+bi`, `a-bi`, `a,b`, or `a`).
 - `animations` encodes `labelA=start..end` for finger labels only.
 - `duration` sets `t=...` in seconds (e.g. `"5s"` or `5`).
-- `compress` defaults to `true` and uses `formulab64` (gzip + base64url). Set
+- `compress=true` uses `formulab64` (gzip + base64url). Set
   `compress=false` to emit a raw `formula=` instead.
 - `includeFormulaParam=true` also includes `formula=` alongside `formulab64`.
 

--- a/api/README.md
+++ b/api/README.md
@@ -9,6 +9,10 @@ and generate shareable URLs (including finger values, animations, and timing).
   - Endpoint: `/api/reflex4you`
   - Method: `POST`
   - Returns: `{ ok, url, caretMessage, caretSelection }`
+- `reflex4you-preview.mjs` – Vercel Serverless Function
+  - Endpoint: `/api/reflex4you-preview`
+  - Method: `GET` or `POST`
+  - Returns: `image/svg+xml` (or JSON when `format=json`)
 
 ## Quick deploy on Vercel (from GitHub)
 
@@ -44,7 +48,7 @@ You can test this on https://hoppscotch.io/, just select POST, select body, cont
   "duration": "6s",
   "solos": ["D1", "D2"],
   "edit": true,
-  "compress": false,
+  "compress": true,
   "includeFormulaParam": false,
   "validate": true,
   "compile": false
@@ -57,16 +61,49 @@ You can test this on https://hoppscotch.io/, just select POST, select body, cont
   strings (`a+bi`, `a-bi`, `a,b`, or `a`).
 - `animations` encodes `labelA=start..end` for finger labels only.
 - `duration` sets `t=...` in seconds (e.g. `"5s"` or `5`).
-- `compress=true` uses `formulab64` (gzip + base64url). Use
-  `includeFormulaParam=true` to also include `formula=` for compatibility.
+- `compress` defaults to `true` and uses `formulab64` (gzip + base64url). Set
+  `compress=false` to emit a raw `formula=` instead.
+- `includeFormulaParam=true` also includes `formula=` alongside `formulab64`.
+
+## Preview endpoint
+
+Render a formula preview image (MathJax SVG):
+
+```json
+POST /api/reflex4you-preview
+{
+  "source": "sin(z^2 + D1)",
+  "values": { "D1": "0.2+0.3i" },
+  "inlineFingerConstants": true,
+  "format": "json"
+}
+```
+
+When `format=json`, the response includes the SVG as a string:
+
+```json
+{
+  "ok": true,
+  "svg": "<svg ...>...</svg>",
+  "latex": "\\operatorname{sin}(z^2 + D_1)",
+  "caretMessage": null,
+  "caretSelection": null
+}
+```
+
+You can also call it via GET for `<img src>` embedding:
+
+```
+/api/reflex4you-preview?formulab64=...&format=svg
+```
 
 ## Example response
 
 ```json
 {
   "ok": true,
-  "url": "https://mikaelmayer.github.io/apps/reflex4you/index.html?formula=sin(z%5E2%20%2B%20D1)%20%24%20z%20-%20D2&D1=0.2-0.3i",
-  "query": "formula=sin(z%5E2%20%2B%20D1)%20%24%20z%20-%20D2&D1=0.2-0.3i",
+  "url": "https://mikaelmayer.github.io/apps/reflex4you/index.html?formulab64=H4sIA...&D1=0.2-0.3i",
+  "query": "formulab64=H4sIA...&D1=0.2-0.3i",
   "warnings": null
 }
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -74,9 +74,9 @@ POST /api/reflex4you-preview
 {
   "source": "sin(z^2 + D1)",
   "values": { "D1": "0.2+0.3i" },
-  "ratio": "1:2",
-  "pixels": 1080,
-  "window": { "xMin": -2, "xMax": 2, "yMin": -4, "yMax": 4 },
+  "height": 8,
+  "pixelWidth": 540,
+  "pixelHeight": 1080,
   "format": "json"
 }
 ```
@@ -86,10 +86,9 @@ When `format=json`, the response includes metadata and a base64 PNG:
 ```json
 {
   "ok": true,
-  "width": 540,
-  "height": 1080,
+  "pixelWidth": 540,
+  "pixelHeight": 1080,
   "ratio": 0.5,
-  "window": { "xMin": -2, "xMax": 2, "yMin": -4, "yMax": 4 },
   "view": { "viewXMin": -2, "viewXMax": 2, "viewYMin": -4, "viewYMax": 4 },
   "image": "iVBORw0KGgoAAA...",
   "imageType": "image/png"
@@ -99,15 +98,14 @@ When `format=json`, the response includes metadata and a base64 PNG:
 You can also call it via GET for `<img src>` embedding:
 
 ```
-/api/reflex4you-preview?formulab64=...&ratio=1:2&pixels=1080
+/api/reflex4you-preview?formulab64=...&height=8&pixels=1080
 ```
 
 ### Preview parameters
 
-- `ratio`: aspect ratio (number or `"W:H"`). Default: `0.5` (1:2).
-- `pixels`: long-side pixel count used with `ratio`. Default: `1080`.
-- `width`/`height`: explicit dimensions (override `ratio`/`pixels`).
-- `window`: view window bounds `{ xMin, xMax, yMin, yMax }`. Default: `{-2..2, -4..4}`.
+- `width` or `height`: view span in the complex plane (centered at 0). Default: `height=8`.
+- `pixels`: long-side pixel count when `pixelWidth`/`pixelHeight` are omitted. Default: `1080` (1:2 aspect).
+- `pixelWidth`/`pixelHeight`: explicit output pixel size (overrides `pixels`).
 - `compile`: when true, validates the formula via GPU compilation before rendering.
 
 ## Example response

--- a/api/README.md
+++ b/api/README.md
@@ -12,7 +12,7 @@ and generate shareable URLs (including finger values, animations, and timing).
 - `reflex4you-preview.mjs` – Vercel Serverless Function
   - Endpoint: `/api/reflex4you-preview`
   - Method: `GET` or `POST`
-  - Returns: `image/svg+xml` (or JSON when `format=json`)
+  - Returns: `image/png` (or JSON when `format=json`)
 
 ## Quick deploy on Vercel (from GitHub)
 
@@ -67,35 +67,48 @@ You can test this on https://hoppscotch.io/, just select POST, select body, cont
 
 ## Preview endpoint
 
-Render a formula preview image (MathJax SVG):
+Render a WebGL preview image via Playwright (PNG):
 
 ```json
 POST /api/reflex4you-preview
 {
   "source": "sin(z^2 + D1)",
   "values": { "D1": "0.2+0.3i" },
-  "inlineFingerConstants": true,
+  "ratio": "1:2",
+  "pixels": 1080,
+  "window": { "xMin": -2, "xMax": 2, "yMin": -4, "yMax": 4 },
   "format": "json"
 }
 ```
 
-When `format=json`, the response includes the SVG as a string:
+When `format=json`, the response includes metadata and a base64 PNG:
 
 ```json
 {
   "ok": true,
-  "svg": "<svg ...>...</svg>",
-  "latex": "\\operatorname{sin}(z^2 + D_1)",
-  "caretMessage": null,
-  "caretSelection": null
+  "width": 540,
+  "height": 1080,
+  "ratio": 0.5,
+  "window": { "xMin": -2, "xMax": 2, "yMin": -4, "yMax": 4 },
+  "view": { "viewXMin": -2, "viewXMax": 2, "viewYMin": -4, "viewYMax": 4 },
+  "image": "iVBORw0KGgoAAA...",
+  "imageType": "image/png"
 }
 ```
 
 You can also call it via GET for `<img src>` embedding:
 
 ```
-/api/reflex4you-preview?formulab64=...&format=svg
+/api/reflex4you-preview?formulab64=...&ratio=1:2&pixels=1080
 ```
+
+### Preview parameters
+
+- `ratio`: aspect ratio (number or `"W:H"`). Default: `0.5` (1:2).
+- `pixels`: long-side pixel count used with `ratio`. Default: `1080`.
+- `width`/`height`: explicit dimensions (override `ratio`/`pixels`).
+- `window`: view window bounds `{ xMin, xMax, yMin, yMax }`. Default: `{-2..2, -4..4}`.
+- `compile`: when true, validates the formula via GPU compilation before rendering.
 
 ## Example response
 

--- a/api/reflex4you-preview.mjs
+++ b/api/reflex4you-preview.mjs
@@ -64,7 +64,6 @@ function readQueryBody(req) {
   if (params.has('source')) body.source = params.get('source');
   if (params.has('formula')) body.formula = params.get('formula');
   if (params.has('formulab64')) body.formulab64 = params.get('formulab64');
-  if (params.has('formula64')) body.formula64 = params.get('formula64');
   if (params.has('values')) {
     const raw = params.get('values');
     if (raw) {
@@ -206,12 +205,12 @@ function resolveFormulaSource(body, errors) {
   if (raw != null && String(raw).trim()) {
     return String(raw);
   }
-  const encoded = body?.formulab64 ?? body?.formula64 ?? null;
+  const encoded = body?.formulab64 ?? null;
   if (encoded != null && String(encoded).trim()) {
     try {
       return decodeFormulaFromBase64Url(encoded);
     } catch (error) {
-      errors.push('Invalid formulab64/formula64 value.');
+      errors.push('Invalid formulab64 value.');
       return null;
     }
   }

--- a/api/reflex4you-preview.mjs
+++ b/api/reflex4you-preview.mjs
@@ -1,0 +1,331 @@
+import { gunzipSync } from 'node:zlib';
+import { parseFormulaInput } from '../apps/reflex4you/arithmetic-parser.mjs';
+import { formatCaretIndicator, getCaretSelection } from '../apps/reflex4you/parse-error-format.mjs';
+import { formulaAstToLatex } from '../apps/reflex4you/formula-renderer.mjs';
+import { mathjax } from 'mathjax-full/js/mathjax.js';
+import { TeX } from 'mathjax-full/js/input/tex.js';
+import { SVG } from 'mathjax-full/js/output/svg.js';
+import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js';
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
+
+const FINGER_LABEL_REGEX = /^(?:[FD]\d+|W[012])$/;
+const ROTATION_LABEL_REGEX = /^(?:RA|RB)$/;
+const ALLOWED_LABEL_REGEX = /^(?:[FD]\d+|W[012]|RA|RB)$/;
+
+const adaptor = liteAdaptor();
+RegisterHTMLHandler(adaptor);
+const tex = new TeX({ packages: ['base', 'ams'] });
+const svg = new SVG({ fontCache: 'none' });
+const mathJaxDoc = mathjax.document('', { InputJax: tex, OutputJax: svg });
+
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function jsonResponse(res, status, payload) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(payload));
+}
+
+async function readJsonBody(req) {
+  if (req.body && typeof req.body === 'object') {
+    return req.body;
+  }
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  if (!chunks.length) {
+    return {};
+  }
+  const text = Buffer.concat(chunks).toString('utf8');
+  if (!text) {
+    return {};
+  }
+  return JSON.parse(text);
+}
+
+function parseBooleanInput(value, fallback = null) {
+  if (value == null) return fallback;
+  if (typeof value === 'boolean') return value;
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes') return true;
+  if (normalized === 'false' || normalized === '0' || normalized === 'no') return false;
+  return fallback;
+}
+
+function readQueryBody(req) {
+  const url = new URL(req.url || '', 'http://localhost');
+  const params = url.searchParams;
+  const body = {};
+  if (params.has('source')) body.source = params.get('source');
+  if (params.has('formula')) body.formula = params.get('formula');
+  if (params.has('formulab64')) body.formulab64 = params.get('formulab64');
+  if (params.has('formula64')) body.formula64 = params.get('formula64');
+  if (params.has('values')) {
+    const raw = params.get('values');
+    if (raw) {
+      body.values = raw;
+      body.__valuesFromQuery = true;
+    }
+  }
+  if (params.has('inlineFingerConstants')) {
+    body.inlineFingerConstants = parseBooleanInput(params.get('inlineFingerConstants'), null);
+  }
+  if (params.has('compactComplexNumbers')) {
+    body.compactComplexNumbers = parseBooleanInput(params.get('compactComplexNumbers'), null);
+  }
+  if (params.has('decimalPlaces')) {
+    body.decimalPlaces = Number(params.get('decimalPlaces'));
+  }
+  if (params.has('decimalSeparator')) {
+    body.decimalSeparator = params.get('decimalSeparator');
+  }
+  if (params.has('format')) {
+    body.format = params.get('format');
+  }
+  return body;
+}
+
+function isFingerLabel(label) {
+  return FINGER_LABEL_REGEX.test(label);
+}
+
+function isRotationLabel(label) {
+  return ROTATION_LABEL_REGEX.test(label);
+}
+
+function parseComplexString(raw) {
+  if (raw == null) return null;
+  const normalized = String(raw).trim().replace(/\s+/g, '');
+  if (!normalized) return null;
+
+  if (normalized.includes(',')) {
+    const parts = normalized.split(',');
+    if (parts.length !== 2) return null;
+    const re = Number(parts[0]);
+    const im = Number(parts[1]);
+    if (!Number.isFinite(re) || !Number.isFinite(im)) return null;
+    return { re, im };
+  }
+
+  if (normalized.endsWith('i')) {
+    const core = normalized.slice(0, -1);
+    if (core === '' || core === '+') return { re: 0, im: 1 };
+    if (core === '-') return { re: 0, im: -1 };
+    const splitIdx = findRealImagSplit(core);
+    if (splitIdx > 0) {
+      const realPart = core.slice(0, splitIdx);
+      const imagPart = core.slice(splitIdx);
+      const re = Number(realPart);
+      const im = Number(imagPart);
+      if (!Number.isFinite(re) || !Number.isFinite(im)) return null;
+      return { re, im };
+    }
+    const im = Number(core);
+    if (!Number.isFinite(im)) return null;
+    return { re: 0, im };
+  }
+
+  const re = Number(normalized);
+  if (!Number.isFinite(re)) return null;
+  return { re, im: 0 };
+}
+
+function findRealImagSplit(core) {
+  for (let i = core.length - 1; i > 0; i -= 1) {
+    const ch = core[i];
+    if (ch !== '+' && ch !== '-') continue;
+    const prev = core[i - 1];
+    if (prev === 'e' || prev === 'E') continue;
+    return i;
+  }
+  return -1;
+}
+
+function parseComplexInput(value) {
+  if (value == null) return null;
+  if (typeof value === 'string' || typeof value === 'number') {
+    return parseComplexString(value);
+  }
+  if (Array.isArray(value)) {
+    if (value.length < 2) return null;
+    const re = Number(value[0]);
+    const im = Number(value[1]);
+    if (!Number.isFinite(re) || !Number.isFinite(im)) return null;
+    return { re, im };
+  }
+  if (typeof value === 'object') {
+    const re = Number(value.re ?? value.x);
+    const im = Number(value.im ?? value.y);
+    if (!Number.isFinite(re) || !Number.isFinite(im)) return null;
+    return { re, im };
+  }
+  return null;
+}
+
+function normalizeFingerValues(input, errors) {
+  const fingerValues = {};
+  if (!input || typeof input !== 'object') {
+    return fingerValues;
+  }
+  for (const rawLabel of Object.keys(input)) {
+    const label = String(rawLabel || '').trim();
+    if (!ALLOWED_LABEL_REGEX.test(label)) {
+      errors.push(`Invalid label "${label}". Allowed: F#, D#, W0/W1/W2, RA, RB.`);
+      continue;
+    }
+    const parsed = parseComplexInput(input[rawLabel]);
+    if (!parsed) {
+      errors.push(`Invalid complex value for "${label}".`);
+      continue;
+    }
+    if (isFingerLabel(label) || isRotationLabel(label)) {
+      fingerValues[label] = { re: parsed.re, im: parsed.im };
+    }
+  }
+  return fingerValues;
+}
+
+function decodeBase64Url(encoded) {
+  const normalized = String(encoded || '').replace(/-/g, '+').replace(/_/g, '/');
+  const padding = '='.repeat((4 - (normalized.length % 4)) % 4);
+  return Buffer.from(normalized + padding, 'base64');
+}
+
+function decodeFormulaFromBase64Url(encoded) {
+  const buffer = decodeBase64Url(encoded);
+  return gunzipSync(buffer).toString('utf8');
+}
+
+function resolveFormulaSource(body, errors) {
+  const raw = body?.source ?? body?.formula ?? null;
+  if (raw != null && String(raw).trim()) {
+    return String(raw);
+  }
+  const encoded = body?.formulab64 ?? body?.formula64 ?? null;
+  if (encoded != null && String(encoded).trim()) {
+    try {
+      return decodeFormulaFromBase64Url(encoded);
+    } catch (error) {
+      errors.push('Invalid formulab64/formula64 value.');
+      return null;
+    }
+  }
+  return null;
+}
+
+function renderLatexToSvg(latex) {
+  const node = mathJaxDoc.convert(String(latex || ''), { display: true });
+  return adaptor.outerHTML(node);
+}
+
+export default async function handler(req, res) {
+  setCors(res);
+
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    jsonResponse(res, 405, { ok: false, error: 'GET or POST only' });
+    return;
+  }
+
+  let body = {};
+  if (req.method === 'GET') {
+    body = readQueryBody(req);
+  } else {
+    try {
+      body = await readJsonBody(req);
+    } catch (error) {
+      jsonResponse(res, 400, { ok: false, error: 'Invalid JSON body' });
+      return;
+    }
+  }
+
+  if (body?.__valuesFromQuery && typeof body.values === 'string') {
+    try {
+      body.values = JSON.parse(body.values);
+    } catch (error) {
+      jsonResponse(res, 400, { ok: false, error: 'Invalid values JSON in query.' });
+      return;
+    }
+  }
+
+  const errors = [];
+  const source = resolveFormulaSource(body, errors);
+  if (!source || !source.trim()) {
+    jsonResponse(res, 400, { ok: false, error: 'source is required', details: errors.length ? errors : null });
+    return;
+  }
+
+  const valuesInput = body?.values ?? body?.fingerValues ?? null;
+  const fingerValues = normalizeFingerValues(valuesInput, errors);
+  if (errors.length) {
+    jsonResponse(res, 400, { ok: false, error: 'Invalid request', details: errors });
+    return;
+  }
+
+  const result = parseFormulaInput(source, { fingerValues });
+  if (!result.ok) {
+    jsonResponse(res, 200, {
+      ok: false,
+      svg: null,
+      latex: null,
+      caretMessage: formatCaretIndicator(source, result),
+      caretSelection: getCaretSelection(source, result),
+    });
+    return;
+  }
+
+  const inlineFingerConstants = body?.inlineFingerConstants === true;
+  const latexOptions = {
+    inlineFingerConstants,
+    fingerValues,
+  };
+  if (body?.compactComplexNumbers === false) {
+    latexOptions.compactComplexNumbers = false;
+  }
+  if (Number.isFinite(body?.decimalPlaces)) {
+    latexOptions.decimalPlaces = Number(body.decimalPlaces);
+  }
+  if (typeof body?.decimalSeparator === 'string' && body.decimalSeparator) {
+    latexOptions.decimalSeparator = body.decimalSeparator;
+  }
+
+  let latex;
+  let svgText;
+  try {
+    latex = formulaAstToLatex(result.value, latexOptions);
+    svgText = renderLatexToSvg(latex);
+  } catch (error) {
+    const message = error?.message ? String(error.message) : String(error || 'Preview render error');
+    jsonResponse(res, 500, { ok: false, error: message });
+    return;
+  }
+
+  const wantsJson =
+    String(body?.format || '').toLowerCase() === 'json' ||
+    String(req.headers?.accept || '').includes('application/json');
+
+  if (wantsJson) {
+    jsonResponse(res, 200, {
+      ok: true,
+      svg: svgText,
+      latex,
+      caretMessage: null,
+      caretSelection: null,
+    });
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'image/svg+xml; charset=utf-8');
+  res.end(svgText);
+}

--- a/api/reflex4you.mjs
+++ b/api/reflex4you.mjs
@@ -286,7 +286,7 @@ export default async function handler(req, res) {
     typeof body?.baseUrl === 'string' && body.baseUrl.trim()
       ? body.baseUrl.trim()
       : DEFAULT_BASE_URL;
-  const compress = body?.compress == null ? true : Boolean(body.compress);
+  const compress = Boolean(body?.compress);
   const includeFormulaParam = Boolean(body?.includeFormulaParam);
   const validate = body?.validate !== false;
   const compile = Boolean(body?.compile);

--- a/api/reflex4you.mjs
+++ b/api/reflex4you.mjs
@@ -286,7 +286,7 @@ export default async function handler(req, res) {
     typeof body?.baseUrl === 'string' && body.baseUrl.trim()
       ? body.baseUrl.trim()
       : DEFAULT_BASE_URL;
-  const compress = Boolean(body?.compress);
+  const compress = body?.compress == null ? true : Boolean(body.compress);
   const includeFormulaParam = Boolean(body?.includeFormulaParam);
   const validate = body?.validate !== false;
   const compile = Boolean(body?.compile);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "mathjax-full": "^3.2.1"
+        "@sparticuz/chromium": "^143.0.4",
+        "playwright-core": "^1.58.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.48.2",
@@ -32,13 +33,17 @@
         "node": ">=18"
       }
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
-      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+    "node_modules/@sparticuz/chromium": {
+      "version": "143.0.4",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-143.0.4.tgz",
+      "integrity": "sha512-/6I7uQTRhRDD2/gGPQ1Gkf+Dqk0RYDACPJDZfSzz0OWk4JmUTonNHPXbrn6UIklOHlnDLf8xAAzkOZKB/cJpLA==",
       "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "tar-fs": "^3.1.1"
+      },
       "engines": {
-        "node": ">=14.6"
+        "node": ">=20.11.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -63,6 +68,111 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
+      "integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -145,15 +255,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -197,6 +298,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -230,15 +340,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -246,11 +347,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -469,24 +584,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mathjax-full": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.1.tgz",
-      "integrity": "sha512-aUz9o16MGZdeiIBwZjAfUBTiJb7LRqzZEl1YOZ8zQMGYIyh1/nxRebxKxjDe9L+xcZCr2OHdzoFBMcd6VnLv9Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esm": "^3.2.25",
-        "mhchemparser": "^4.1.0",
-        "mj-context-menu": "^0.6.1",
-        "speech-rule-engine": "^4.0.6"
-      }
-    },
-    "node_modules/mhchemparser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
-      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -510,12 +607,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mj-context-menu": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
-      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -534,6 +625,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/opener": {
@@ -566,6 +666,18 @@
       }
     },
     "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
       "version": "1.56.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
       "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
@@ -590,6 +702,16 @@
       },
       "engines": {
         "node": ">= 10.12"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -712,18 +834,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/speech-rule-engine": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.2.tgz",
-      "integrity": "sha512-S6ji+flMEga+1QU79NDbwZ8Ivf0S/MpupQQiIC0rTpU/ZTKgcajijJJb1OcByBQDjrXCN1/DJtGz4ZJeBMPGJw==",
-      "license": "Apache-2.0",
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "0.9.8",
-        "commander": "13.1.0",
-        "wicked-good-xpath": "1.3.0"
-      },
-      "bin": {
-        "sre": "bin/sre"
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/supports-color": {
@@ -737,6 +856,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/union": {
@@ -771,11 +924,11 @@
         "node": ">=12"
       }
     },
-    "node_modules/wicked-good-xpath": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
-      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
-      "license": "MIT"
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "workspace",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "mathjax-full": "^3.2.1"
+      },
       "devDependencies": {
         "@playwright/test": "^1.48.2",
         "http-server": "^14.1.1"
@@ -27,6 +30,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/ansi-styles": {
@@ -133,6 +145,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -207,6 +228,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -439,6 +469,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mathjax-full": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.1.tgz",
+      "integrity": "sha512-aUz9o16MGZdeiIBwZjAfUBTiJb7LRqzZEl1YOZ8zQMGYIyh1/nxRebxKxjDe9L+xcZCr2OHdzoFBMcd6VnLv9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -461,6 +509,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
+      "license": "Apache-2.0"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -658,6 +712,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/speech-rule-engine": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.2.tgz",
+      "integrity": "sha512-S6ji+flMEga+1QU79NDbwZ8Ivf0S/MpupQQiIC0rTpU/ZTKgcajijJJb1OcByBQDjrXCN1/DJtGz4ZJeBMPGJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "0.9.8",
+        "commander": "13.1.0",
+        "wicked-good-xpath": "1.3.0"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -702,6 +770,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "devDependencies": {
     "@playwright/test": "^1.48.2",
     "http-server": "^14.1.1"
+  },
+  "dependencies": {
+    "mathjax-full": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "http-server": "^14.1.1"
   },
   "dependencies": {
-    "mathjax-full": "^3.2.1"
+    "@sparticuz/chromium": "^143.0.4",
+    "playwright-core": "^1.58.1"
   }
 }


### PR DESCRIPTION
Adds a new API endpoint `/api/reflex4you-preview` to generate MathJax SVG previews of formulas and updates the main API to default to `formulab64` for compressed formulas.

The preview endpoint returns a MathJax-rendered SVG of the formula text, as a direct WebGL visualization screenshot is not feasible in a serverless environment. The main API now defaults to using `formulab64` (gzip+base64url) for formula parameters, improving URL efficiency.

---
<a href="https://cursor.com/background-agent?bcId=bc-005c47b5-e555-4dcd-a93f-a271caff8d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-005c47b5-e555-4dcd-a93f-a271caff8d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

