### PR TITLE
MathJax argument spelling

### DIFF
--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -333,7 +333,8 @@ test('renders argument literals with full label and highlights', () => {
   const highlightedLatex = formulaAstToLatex(highlighted.value);
   assert.match(highlightedLatex, /\\operatorname\{/);
   assert.match(highlightedLatex, /\{\\Huge U\}/);
-  assert.match(highlightedLatex, /ment\\right\)/);
+  assert.match(highlightedLatex, /arg\{\\Huge U\}ment/);
+  assert.match(highlightedLatex, /\\left\(z\\right\)/);
 });
 
 test('arg(z, k) forwards the branch argument (like ln)', () => {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -322,6 +322,20 @@ test('parses arg(z) and argument(z) calls', () => {
   assert.equal(argumentResult.value.branch, null);
 });
 
+test('renders argument literals with full label and highlights', () => {
+  const literal = parseFormulaInput('argument');
+  assert.equal(literal.ok, true);
+  const literalLatex = formulaAstToLatex(literal.value);
+  assert.match(literalLatex, /\\operatorname\{argument\}\\left\(z\\right\)/);
+
+  const highlighted = parseFormulaInput('arg_ument');
+  assert.equal(highlighted.ok, true);
+  const highlightedLatex = formulaAstToLatex(highlighted.value);
+  assert.match(highlightedLatex, /\\operatorname\{/);
+  assert.match(highlightedLatex, /\{\\Huge U\}/);
+  assert.match(highlightedLatex, /ment\\right\)/);
+});
+
 test('arg(z, k) forwards the branch argument (like ln)', () => {
   const result = parseFormulaInput('arg(z, x + 1)');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1317,7 +1317,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=44.0';
+    const SW_URL = './service-worker.js?sw=45.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula.html
+++ b/apps/reflex4you/formula.html
@@ -277,35 +277,6 @@
       letter-spacing: 0.02em;
     }
 
-    .block-help {
-      margin: 0 0 10px;
-      font-size: 12px;
-      color: rgba(255, 255, 255, 0.72);
-      line-height: 1.4;
-    }
-
-    .stale-warning {
-      display: none;
-      margin: 0 0 12px;
-      padding: 10px 12px;
-      border-radius: 12px;
-      border: 1px solid rgba(255, 210, 125, 0.35);
-      background: rgba(40, 26, 0, 0.45);
-      color: rgba(255, 235, 200, 0.92);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-      font-size: 12px;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-
-    .stale-actions {
-      display: none;
-      margin: 0 0 12px;
-      gap: 10px;
-      align-items: center;
-      flex-wrap: wrap;
-    }
-
     .btn {
       appearance: none;
       border: 1px solid rgba(255, 255, 255, 0.16);
@@ -374,17 +345,15 @@
       outline: none;
     }
 
-    .build-info {
-      margin: 0 0 12px;
-      padding: 10px 12px;
-      border-radius: 12px;
-      border: 1px solid rgba(255, 255, 255, 0.10);
-      background: rgba(0, 0, 0, 0.20);
-      color: rgba(255, 255, 255, 0.82);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    .controls__toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
       font-size: 12px;
-      white-space: pre-wrap;
-      word-break: break-word;
+      color: var(--muted);
+    }
+    .controls__checkbox {
+      margin: 0;
     }
 
     /* Canvas is responsive; JS sizes the backing store to match. */
@@ -430,28 +399,25 @@
 
     <div class="card">
       <div class="card__body">
-        <pre id="stale-warning" class="stale-warning" aria-live="polite"></pre>
-        <div id="stale-actions" class="stale-actions">
-          <button id="fix-cache" class="btn" type="button">Fix cache now (unregister SW + clear caches)</button>
-          <button id="refresh-build" class="btn" type="button">Re-check build info</button>
-        </div>
-        <pre id="build-info" class="build-info" aria-label="Build info"></pre>
         <div class="editor">
-          <p class="editor__label">Reflex source (updates live)</p>
-          <textarea id="formula-input" class="editor__input" spellcheck="false" aria-label="Formula source"></textarea>
+          <p class="editor__label">Formula</p>
+          <textarea id="formula-input" class="editor__input" spellcheck="false" aria-label="Formula"></textarea>
         </div>
         <pre id="formula-error" class="error" aria-live="polite"></pre>
         <p class="block-label">Preview (Canvas)</p>
-        <p class="block-help">This is rasterized from MathJax’s SVG output and drawn onto a canvas.</p>
         <div class="controls">
           <div class="controls__field">
-            <span class="controls__label">Canvas background (RRGGBBAA)</span>
-            <input id="bghex" class="controls__input" type="text" value="ffffff80" spellcheck="false" inputmode="text" aria-label="Canvas background in RRGGBBAA hex" />
+            <span class="controls__label">Canvas background</span>
             <button class="preset" type="button" data-bghex="ffffff80" data-fghex="000000ff">white50</button>
             <button class="preset" type="button" data-bghex="00000080" data-fghex="ffffffff">black50</button>
-            <button class="preset" type="button" data-bghex="1e3a8aff" data-fghex="000000ff">blue</button>
-            <button class="preset" type="button" data-bghex="000000ff" data-fghex="000000ff">black</button>
-            <button class="preset" type="button" data-bghex="00000000" data-fghex="000000ff">transparent</button>
+            <span class="controls__label">custom</span>
+            <input id="bghex" class="controls__input" type="text" value="ffffff80" spellcheck="false" inputmode="text" aria-label="Custom canvas background in RRGGBBAA hex" />
+          </div>
+          <div class="controls__field">
+            <label class="controls__toggle" for="inline-fingers">
+              <input id="inline-fingers" class="controls__checkbox" type="checkbox" />
+              Inline finger constants
+            </label>
           </div>
           <button id="download-png" class="btn" type="button" disabled>Download PNG</button>
         </div>
@@ -467,163 +433,6 @@
     const HTML_BUILD_ID = '__REFLEX_BUILD_ID__';
     window.__reflexHtmlBuildId = HTML_BUILD_ID;
     import(`./formula-page.mjs?build=${encodeURIComponent(HTML_BUILD_ID)}`);
-  </script>
-  <script>
-    // Non-module diagnostics so it still runs even if module caching is stale.
-    (function () {
-      function $(id) { return document.getElementById(id); }
-      const startedAt = Date.now();
-
-      function setText(id, text) {
-        const el = $(id);
-        if (!el) return;
-        el.textContent = String(text || '');
-      }
-
-      function show(id, show) {
-        const el = $(id);
-        if (!el) return;
-        el.style.display = show ? 'block' : 'none';
-      }
-
-      function getControllerInfo() {
-        try {
-          const ctrl = navigator && navigator.serviceWorker && navigator.serviceWorker.controller;
-          if (!ctrl) return 'Controller: none (not controlled)';
-          return `Controller: ${ctrl.scriptURL}`;
-        } catch (_) {
-          return 'Controller: unknown';
-        }
-      }
-
-      async function probeLatestBuildId(url) {
-        try {
-          const res = await fetch(url, { cache: 'no-store' });
-          const text = await res.text();
-          const m = /FORMULA_RENDERER_BUILD_ID\s*=\s*'([^']+)'/.exec(text);
-          return m ? m[1] : null;
-        } catch (_) {
-          return null;
-        }
-      }
-
-      async function refreshBuildInfo() {
-        const render = $('formula-render');
-        const runningBuild = render && render.dataset ? (render.dataset.rendererBuildId || '') : '';
-        const latex = render && render.dataset ? (render.dataset.latex || '') : '';
-
-        const latestBuild = await probeLatestBuildId(`./formula-renderer.mjs?probe=${Date.now()}`);
-        const controller = navigator?.serviceWorker?.controller?.scriptURL || '';
-        const isControlled = Boolean(controller);
-
-        const lines = [
-          getControllerInfo(),
-          `Running renderer build: ${runningBuild || '(missing)'}`,
-          `Latest available renderer build: ${latestBuild || '(unavailable)'}`,
-          latex ? `Latex preview (first 140 chars): ${latex.slice(0, 140)}` : 'Latex preview: (not rendered yet)',
-          '',
-          'Manual verification: open ./formula-renderer.mjs and search for FORMULA_RENDERER_BUILD_ID.',
-        ];
-        setText('build-info', lines.join('\n'));
-
-        // Avoid false positives: on slow/blocked third-party loads, the renderer
-        // may not have populated dataset fields yet. Only warn once we have
-        // evidence of a mismatch, or (when controlled by a SW) a prolonged
-        // failure to initialize.
-        const mismatch = Boolean(latestBuild && runningBuild && latestBuild !== runningBuild);
-        const missingTooLong = !runningBuild && (Date.now() - startedAt) > 2500;
-        const looksOld = mismatch || (isControlled && missingTooLong);
-
-        if (looksOld) {
-          show('stale-warning', true);
-          show('stale-actions', true);
-          setText(
-            'stale-warning',
-            [
-              'WARNING: This page appears to be running stale/mismatched cached JS.',
-              'If you are on a PR preview, cache collisions across deployments are common.',
-              '',
-              mismatch ? `Detected: renderer build mismatch (${runningBuild || 'missing'} != ${latestBuild || 'unknown'}).` : 'Detected: renderer did not initialize (build id missing).',
-              isControlled ? `Controller: ${controller}` : 'Controller: none (not controlled)',
-              '',
-              'Try: hard reload, or Application → Service Workers → Unregister; then reload.',
-            ].join('\n'),
-          );
-
-          // Auto-heal once per tab, but only when we have a *confirmed mismatch*.
-          // (Avoid reload loops when the page is simply still initializing.)
-          if (mismatch) {
-            try {
-              const key = 'reflex4you:autoFixTried';
-              if (!sessionStorage.getItem(key)) {
-                sessionStorage.setItem(key, String(Date.now()));
-                // Defer so the warning is visible briefly.
-                window.setTimeout(() => fixCacheNow(), 250);
-              }
-            } catch (_) {
-              // ignore storage failures; user can still click the button
-            }
-          }
-        } else {
-          show('stale-warning', false);
-          show('stale-actions', false);
-        }
-      }
-
-      async function fixCacheNow() {
-        // Best-effort: unregister any SW whose scope matches this directory, then clear reflex caches.
-        const logs = [];
-        try {
-          if (navigator?.serviceWorker?.getRegistrations) {
-            const regs = await navigator.serviceWorker.getRegistrations();
-            const scopePrefix = String(new URL('./', location.href));
-            const pathPrefix = String(location.pathname || '').replace(/[^/]*$/, ''); // "/.../reflex4you/"
-            for (const reg of regs) {
-              const scope = reg?.scope ? String(reg.scope) : '';
-              if (scope && (scope.startsWith(scopePrefix) || (pathPrefix && scope.includes(pathPrefix)))) {
-                const ok = await reg.unregister();
-                logs.push(`unregister ${scope}: ${ok ? 'ok' : 'failed'}`);
-              }
-            }
-          }
-        } catch (e) {
-          logs.push(`unregister failed: ${e?.message || e}`);
-        }
-
-        try {
-          if (window.caches?.keys) {
-            const keys = await caches.keys();
-            for (const key of keys) {
-              if (key.startsWith('reflex4you:') || key.startsWith('reflex4you-')) {
-                await caches.delete(key);
-              }
-            }
-            logs.push('cache delete: ok');
-          }
-        } catch (e) {
-          logs.push(`cache delete failed: ${e?.message || e}`);
-        }
-
-        setText('build-info', `${$('build-info')?.textContent || ''}\n\nFix-cache log:\n${logs.join('\n')}`);
-        // Reload with cache-busting query.
-        location.replace(`${location.pathname}${location.search}${location.hash}`.replace(/([?&])nocache=\d+(&|$)/, '$1').replace(/\?$/, '') + (location.search ? '&' : '?') + `nocache=${Date.now()}`);
-      }
-
-      // Give modules a moment to render, then probe; repeat once.
-      window.addEventListener('load', () => {
-        refreshBuildInfo();
-        window.setTimeout(refreshBuildInfo, 1200);
-
-        const fixBtn = $('fix-cache');
-        if (fixBtn) {
-          fixBtn.addEventListener('click', () => fixCacheNow());
-        }
-        const refreshBtn = $('refresh-build');
-        if (refreshBtn) {
-          refreshBtn.addEventListener('click', () => refreshBuildInfo());
-        }
-      });
-    })();
   </script>
 </body>
 </html>

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1079,7 +1079,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v44</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v45</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -269,7 +269,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator only if it hangs > 1s.
 setCompileOverlayPhase('Loading…', { resetStart: true });
 
-const APP_VERSION = 44;
+const APP_VERSION = 45;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4524,7 +4524,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=44.0';
+  const SW_URL = './service-worker.js?sw=45.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '44.0';
+const CACHE_MINOR = '45.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Ensure MathJax rendering of "argument" and "arg_ument" in `apps/reflex4you` matches the original formula's spelling and highlighting.

Previously, "argument" was rendered as "arg", and the `_ument` highlighting was lost. This change propagates the original syntax label and identifier highlights to preserve the full word and specific formatting.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b49d2df-69cf-4b98-91bd-f127354cc7da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b49d2df-69cf-4b98-91bd-f127354cc7da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

