### PR TITLE
Non-integer formula parsing

### DIFF
--- a/apps/reflex4you/arithmetic-parser.mjs
+++ b/apps/reflex4you/arithmetic-parser.mjs
@@ -2483,6 +2483,7 @@ function findBindingForName(env, name) {
 function normalizeParseOptions(options = {}) {
   return {
     fingerValues: normalizeFingerValuesSource(options.fingerValues),
+    resolveRepeatComposeCounts: options.resolveRepeatComposeCounts !== false,
   };
 }
 
@@ -2565,9 +2566,12 @@ function resolveRepeatPlaceholders(ast, parseOptions, input) {
           node.countSpan ||
           node.span ||
           (parent?.span ?? input.createSpan(0, 0));
-        const count = evaluateRepeatCountExpression(node.countExpression, span, context, input);
-        if (count instanceof ParseFailure) {
-          return count;
+        let count;
+        if (parseOptions.resolveRepeatComposeCounts) {
+          count = evaluateRepeatCountExpression(node.countExpression, span, context, input);
+          if (count instanceof ParseFailure) {
+            return count;
+          }
         }
         const composeMultiple = createComposeMultipleNode({
           base: node.base,

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -206,6 +206,16 @@ test('renders exp(x) as e^{x} (unless underscore-highlight syntax is used)', () 
   assert.match(highlightedLatex, /\\left\(z\\right\)/);
 });
 
+test('renders exp_(x) as plain exp(x)', () => {
+  const result = parseFormulaInput('exp_(z)');
+  assert.equal(result.ok, true);
+  assert.equal(result.value.kind, 'Exp');
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /\\operatorname\{exp\}/);
+  assert.match(latex, /\\left\(z\\right\)/);
+  assert.doesNotMatch(latex, /^e\^\{z\}$/);
+});
+
 test('renders greek-letter identifiers as symbols (unless underscores are present)', () => {
   const result = parseFormulaInput('set pi = 0 in set tau = 0 in set delta = 0 in set phi = 0 in pi + tau + delta + phi');
   assert.equal(result.ok, true);
@@ -224,6 +234,14 @@ test('renders greek-letter identifiers as symbols (unless underscores are presen
   assert.match(highlightedLatex, /\\pi_\{1\}/);
   // The reference keeps the digit highlight, so the 1 is rendered Huge (in the subscript).
   assert.match(highlightedLatex, /\{\\Huge 1\}/);
+});
+
+test('renders trailing-underscore identifiers in plain text', () => {
+  const result = parseFormulaInput('pi_');
+  assert.equal(result.ok, true);
+  const latex = formulaAstToLatex(result.value);
+  assert.match(latex, /pi/);
+  assert.doesNotMatch(latex, /\\pi/);
 });
 
 test('renders gamma_1 as "gamma" followed by a big 1', () => {

--- a/apps/reflex4you/arithmetic-parser.test.mjs
+++ b/apps/reflex4you/arithmetic-parser.test.mjs
@@ -236,14 +236,6 @@ test('renders greek-letter identifiers as symbols (unless underscores are presen
   assert.match(highlightedLatex, /\{\\Huge 1\}/);
 });
 
-test('renders trailing-underscore identifiers in plain text', () => {
-  const result = parseFormulaInput('pi_');
-  assert.equal(result.ok, true);
-  const latex = formulaAstToLatex(result.value);
-  assert.match(latex, /pi/);
-  assert.doesNotMatch(latex, /\\pi/);
-});
-
 test('renders gamma_1 as "gamma" followed by a big 1', () => {
   const result = parseFormulaInput('set gamma_1 = 0 in gamma_1');
   assert.equal(result.ok, true);

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1317,7 +1317,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=45.0';
+    const SW_URL = './service-worker.js?sw=46.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -16,7 +16,7 @@ import { setupMenuDropdown } from './menu-ui.mjs';
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=45.0';
+  const SW_URL = './service-worker.js?sw=46.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -362,7 +362,7 @@ function clearRender() {
 
 async function renderFromSource(source) {
   const normalized = String(source || '');
-  const parsed = parseFormulaInput(normalized);
+  const parsed = parseFormulaInput(normalized, { resolveRepeatComposeCounts: false });
   if (!parsed.ok) {
     showParseError(normalized, parsed);
     clearRender();

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1079,7 +1079,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v45</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v46</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -269,7 +269,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator only if it hangs > 1s.
 setCompileOverlayPhase('Loading…', { resetStart: true });
 
-const APP_VERSION = 45;
+const APP_VERSION = 46;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4524,7 +4524,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=45.0';
+  const SW_URL = './service-worker.js?sw=46.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '45.0';
+const CACHE_MINOR = '46.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope


### PR DESCRIPTION
Add an option to skip `$$` repeat count resolution and apply it to `formula-page.mjs`.

This allows non-integer expressions after `$$` in `formula.html` by preventing their resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f8bc7d3-73c5-4eb6-9b7b-5e2d54432797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f8bc7d3-73c5-4eb6-9b7b-5e2d54432797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

