### PR TITLE
Formula image margins

### DIFF
--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1317,7 +1317,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=45.0';
+    const SW_URL = './service-worker.js?sw=46.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -43,7 +43,11 @@ if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
 const DEFAULT_FORMULA_TEXT = 'z';
 const DEFAULT_CANVAS_BG_HEX = 'ffffff80';
 const DEFAULT_CANVAS_FG_HEX = '000000ff';
+const EXPORT_CROP_PADDING_PX = 8;
+const EXPORT_CROP_COLOR_TOLERANCE = 10;
+const EXPORT_CROP_ALPHA_TOLERANCE = 10;
 let currentCanvasFgHex = DEFAULT_CANVAS_FG_HEX;
+let lastRenderState = null;
 
 function $(id) {
   return document.getElementById(id);

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -17,7 +17,7 @@ import { setupMenuDropdown } from './menu-ui.mjs';
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=45.0';
+  const SW_URL = './service-worker.js?sw=46.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -4524,7 +4524,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=45.0';
+  const SW_URL = './service-worker.js?sw=46.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.


### PR DESCRIPTION
Remove variable top/bottom margins from downloaded formula images by cropping to content bounds with uniform padding.

The previous download mechanism produced images with inconsistent and often excessive vertical margins, making them difficult to use directly. This PR introduces an offscreen re-render and content-aware cropping to ensure the downloaded image tightly fits the formula with a consistent, small padding.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e07d9cd-a429-4c03-b3f4-f542acac966d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e07d9cd-a429-4c03-b3f4-f542acac966d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

