### PR TITLE
Formulab64 parameter error

### DIFF
--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1360,8 +1360,12 @@ async function bootstrap() {
   await verifyCompressionSupport();
 
   // Read formula from URL.
+  let initialFormulaDecodeMessage = null;
   const decoded = await readFormulaFromQuery({
-    onDecodeError: () => showError('We could not decode the formula embedded in this link.'),
+    onDecodeError: (_error, message) => {
+      initialFormulaDecodeMessage =
+        message || 'Could not decode formulab64 query parameter. Loaded the default formula.';
+    },
   });
   activeFormulaSource = (decoded && String(decoded).trim()) ? String(decoded) : 'z';
 
@@ -1393,6 +1397,9 @@ async function bootstrap() {
   if (fingerState.mode === 'invalid') {
     showError(fingerState.error);
     return;
+  }
+  if (parsed.ok && initialFormulaDecodeMessage) {
+    showError(initialFormulaDecodeMessage);
   }
 
   allUsedLabels = sortedLabels([

--- a/apps/reflex4you/explore-page.mjs
+++ b/apps/reflex4you/explore-page.mjs
@@ -1317,7 +1317,7 @@ async function handleMenuAction(action) {
 async function bootstrap() {
   // Service worker (same behavior as other pages).
   if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-    const SW_URL = './service-worker.js?sw=46.0';
+    const SW_URL = './service-worker.js?sw=47.0';
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(SW_URL).then((registration) => {
         if (registration?.waiting) {

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -17,7 +17,7 @@ import { setupMenuDropdown } from './menu-ui.mjs';
 // on the formula page (e.g. from a shared link).
 if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=46.0';
+  const SW_URL = './service-worker.js?sw=47.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Match the viewer page behavior: activate updated workers ASAP so

--- a/apps/reflex4you/formula-page.mjs
+++ b/apps/reflex4you/formula-page.mjs
@@ -605,9 +605,11 @@ async function bootstrap() {
     },
   });
 
+  let initialFormulaDecodeMessage = null;
   const decoded = await readFormulaFromQuery({
-    onDecodeError: () => {
-      showError('We could not decode the formula embedded in this link.');
+    onDecodeError: (_error, message) => {
+      initialFormulaDecodeMessage =
+        message || 'Could not decode formulab64 query parameter. Loaded the default formula.';
     },
   });
   initialFormulaFromUrl = decoded;
@@ -725,7 +727,10 @@ async function bootstrap() {
     });
   }
 
-  await renderFromSource(source);
+  const initialRender = await renderFromSource(source);
+  if (initialRender.ok && initialFormulaDecodeMessage) {
+    showError(initialFormulaDecodeMessage);
+  }
 
   // Live edit + render loop.
   if (inputEl) {

--- a/apps/reflex4you/index.html
+++ b/apps/reflex4you/index.html
@@ -1079,7 +1079,7 @@
       </div>
     </div>
   </div>
-  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v46</div>
+  <div id="app-version-pill" aria-live="polite" aria-label="Reflex4You version">v47</div>
 </div>
 
 <div id="error"></div>

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -3198,9 +3198,11 @@ async function bootstrapReflexApplication() {
   const params = new URLSearchParams(window.location.search);
   animationSeconds = parseSecondsFromQuery(params.get(ANIMATION_TIME_PARAM)) ?? DEFAULT_ANIMATION_SECONDS;
 
+  let initialFormulaDecodeMessage = null;
   let initialFormulaSource = await readFormulaFromQuery({
-    onDecodeError: () => {
-      showError('We could not decode the formula embedded in this link. Resetting to the default formula.');
+    onDecodeError: (_error, message) => {
+      initialFormulaDecodeMessage =
+        message || 'Could not decode formulab64 query parameter. Loaded the default formula.';
     },
   });
   if (!initialFormulaSource || !initialFormulaSource.trim()) {
@@ -3223,6 +3225,8 @@ async function bootstrapReflexApplication() {
   const initialFingerState = deriveFingerState(initialUsage);
   if (initialFingerState.mode === 'invalid') {
     showError(initialFingerState.error);
+  } else if (initialParse.ok && initialFormulaDecodeMessage) {
+    showError(initialFormulaDecodeMessage);
   }
 
   formulaTextarea.value = initialFormulaSource;

--- a/apps/reflex4you/main.js
+++ b/apps/reflex4you/main.js
@@ -269,7 +269,7 @@ function setCompileOverlayVisible(visible, message = null) {
 // Show a cold-start loading indicator only if it hangs > 1s.
 setCompileOverlayPhase('Loading…', { resetStart: true });
 
-const APP_VERSION = 46;
+const APP_VERSION = 47;
 const CONTEXT_LOSS_RELOAD_KEY = `reflex4you:contextLossReloaded:v${APP_VERSION}`;
 const RESUME_RELOAD_KEY = `reflex4you:resumeReloaded:v${APP_VERSION}`;
 const LAST_HIDDEN_AT_KEY = `reflex4you:lastHiddenAtMs:v${APP_VERSION}`;
@@ -4528,7 +4528,7 @@ function triggerImageDownload(url, filename, shouldRevoke) {
 
 if ('serviceWorker' in navigator) {
   // Version the SW script URL so updates can't get stuck behind a cached SW script.
-  const SW_URL = './service-worker.js?sw=46.0';
+  const SW_URL = './service-worker.js?sw=47.0';
   window.addEventListener('load', () => {
     navigator.serviceWorker.register(SW_URL).then((registration) => {
       // Auto-activate updated workers so cache/version bumps take effect quickly.

--- a/apps/reflex4you/service-worker.js
+++ b/apps/reflex4you/service-worker.js
@@ -7,7 +7,7 @@
 // PR previews under `/pr-preview/...`). If we use a single global cache name, different
 // deployments can overwrite each other and serve stale/mismatched assets.
 // Include the service worker registration scope in cache keys to isolate deployments.
-const CACHE_MINOR = '46.0';
+const CACHE_MINOR = '47.0';
 const SCOPE =
   typeof self !== 'undefined' && self.registration && typeof self.registration.scope === 'string'
     ? self.registration.scope

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -260,19 +260,17 @@ test('reflex4you loads formulas from query string on startup', async ({ page }) 
   await expectNoRendererError(page);
 });
 
-test('reflex4you reports invalid formulab64 while loading default formula', async ({ page }) => {
+test('formula page reports invalid formulab64 while loading default formula', async ({ page }) => {
   // "hello" as base64url decodes, but is not valid gzip payload for formulab64.
-  await page.goto('/index.html?formulab64=aGVsbG8');
-  await waitForReflexReady(page);
+  await page.goto('/formula.html?formulab64=aGVsbG8');
 
-  const textarea = page.locator('#formula');
+  const textarea = page.locator('#formula-input');
   await expect(textarea).toHaveValue('z');
 
-  const error = page.locator('#error');
+  const error = page.locator('#formula-error');
   await expect(error).toBeVisible();
   await expect(error).toContainText('formulab64');
   await expect(error).toContainText('default formula');
-  await expect.poll(async () => await error.getAttribute('data-error-severity')).toBe('error');
 });
 
 test('reflex4you upgrades legacy formula query param to formulab64', async ({ page }) => {

--- a/apps/reflex4you/tests/reflex4you.spec.js
+++ b/apps/reflex4you/tests/reflex4you.spec.js
@@ -260,6 +260,21 @@ test('reflex4you loads formulas from query string on startup', async ({ page }) 
   await expectNoRendererError(page);
 });
 
+test('reflex4you reports invalid formulab64 while loading default formula', async ({ page }) => {
+  // "hello" as base64url decodes, but is not valid gzip payload for formulab64.
+  await page.goto('/index.html?formulab64=aGVsbG8');
+  await waitForReflexReady(page);
+
+  const textarea = page.locator('#formula');
+  await expect(textarea).toHaveValue('z');
+
+  const error = page.locator('#error');
+  await expect(error).toBeVisible();
+  await expect(error).toContainText('formulab64');
+  await expect(error).toContainText('default formula');
+  await expect.poll(async () => await error.getAttribute('data-error-severity')).toBe('error');
+});
+
 test('reflex4you upgrades legacy formula query param to formulab64', async ({ page }) => {
   const supportsCompression = await detectCompressionCapability(page);
   await page.goto(`/index.html?formula=${encodeURIComponent(SEEDED_FORMULA)}`);


### PR DESCRIPTION
Show a user-visible error message when the `formulab64` URL parameter is invalid, instead of silently falling back to the default formula.

The existing error handling for `formulab64` decode failures was clearing the error message too early during application bootstrap, making the fallback to the default formula appear silent to the user. This PR ensures the error message is displayed after initialization.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-bebd75e7-a704-4651-b34b-5445d11fbf72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bebd75e7-a704-4651-b34b-5445d11fbf72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

