### PR TITLE
videodelay: add bottom-left picture capture and update zoom steps

### DIFF
--- a/apps/videodelay/app.js
+++ b/apps/videodelay/app.js
@@ -10,6 +10,7 @@
   const delayLabel = document.getElementById('delayLabel');
   const switchBtn = document.getElementById('switchBtn');
   const copyLinkBtn = document.getElementById('copyLinkBtn');
+  const picBtn = document.getElementById('picBtn');
   const recBtn = document.getElementById('recBtn');
   const cancelBtn = document.getElementById('cancelBtn');
   const recordDot = document.getElementById('recordDot');
@@ -147,6 +148,12 @@
         return 'mp4';
       case 'video/ogg':
         return 'ogv';
+      case 'image/jpeg':
+        return 'jpg';
+      case 'image/png':
+        return 'png';
+      case 'image/webp':
+        return 'webp';
       case 'video/webm':
       default:
         return 'webm';
@@ -166,7 +173,7 @@
           suggestedName,
           types: [
             {
-              description: 'Video',
+              description: 'Media',
               accept: { [normalizeMimeType(blob.type)]: [ext] }
             }
           ]
@@ -201,16 +208,92 @@
     return clicked;
   }
 
-  async function shareBlobOrSave(blob, suggestedName) {
+  async function shareBlobOrSave(blob, suggestedName, shareTitle) {
     try {
-      const file = new File([blob], suggestedName, { type: blob.type || 'video/mp4' });
+      const file = new File([blob], suggestedName, { type: blob.type || 'application/octet-stream' });
       const canShareFiles = typeof navigator !== 'undefined' && navigator.canShare && navigator.canShare({ files: [file] });
       if (canShareFiles && typeof navigator.share === 'function') {
-        await navigator.share({ files: [file], title: 'Delayed recording' });
+        await navigator.share({ files: [file], title: shareTitle || 'Delayed capture' });
         return true;
       }
     } catch (_) { /* fallback to save */ }
     return saveBlobAs(blob, suggestedName);
+  }
+
+  function extractCssUrl(value) {
+    const m = /^url\((['"]?)(.+?)\1\)$/.exec(String(value || '').trim());
+    return m ? m[2] : '';
+  }
+
+  function imageFromUrl(url) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = reject;
+      img.src = url;
+    });
+  }
+
+  function getCurrentMainViewSource() {
+    if (!delayProcessActive || mainIsLive) return liveVideo;
+    if (delayReady) return delayedVideo;
+    return frozenView;
+  }
+
+  async function capturePhotoBlobFromCurrentView() {
+    const source = getCurrentMainViewSource();
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas not supported');
+
+    if (source === frozenView) {
+      const bgUrl = extractCssUrl(frozenView.style.backgroundImage);
+      if (bgUrl) {
+        const img = await imageFromUrl(bgUrl);
+        const w = img.naturalWidth || 1280;
+        const h = img.naturalHeight || 720;
+        canvas.width = w;
+        canvas.height = h;
+        ctx.drawImage(img, 0, 0, w, h);
+      } else {
+        const w = liveVideo.videoWidth || 1280;
+        const h = liveVideo.videoHeight || 720;
+        canvas.width = w;
+        canvas.height = h;
+        ctx.drawImage(liveVideo, 0, 0, w, h);
+      }
+    } else {
+      const w = source.videoWidth || 0;
+      const h = source.videoHeight || 0;
+      if (!w || !h) throw new Error('Video frame not ready');
+      canvas.width = w;
+      canvas.height = h;
+      ctx.drawImage(source, 0, 0, w, h);
+    }
+
+    return new Promise((resolve, reject) => {
+      canvas.toBlob(blob => {
+        if (blob && blob.size > 0) resolve(blob);
+        else reject(new Error('Could not encode image'));
+      }, 'image/jpeg', 0.92);
+    });
+  }
+
+  async function takePicture() {
+    if (!picBtn) return;
+    const previous = picBtn.textContent || 'PIC';
+    try {
+      picBtn.disabled = true;
+      picBtn.textContent = '...';
+      const blob = await capturePhotoBlobFromCurrentView();
+      const filename = `delayed-picture-${Date.now()}.${getExtensionFromMime(blob.type)}`;
+      await shareBlobOrSave(blob, filename, 'Delayed snapshot');
+    } catch (e) {
+      console.error('Picture capture failed', e);
+    } finally {
+      picBtn.disabled = false;
+      picBtn.textContent = previous;
+    }
   }
 
   // ========================================================================
@@ -675,7 +758,7 @@
         const filename = `delayed-recording-${Date.now()}.${ext}`;
         try {
           recBtn.disabled = true;
-          await shareBlobOrSave(blob, filename);
+          await shareBlobOrSave(blob, filename, 'Delayed recording');
         } finally {
           recBtn.disabled = false;
           recBtn.textContent = 'REC';
@@ -844,6 +927,11 @@
   // REC button
   recBtn.addEventListener('click', () => { void toggleRecording(); });
 
+  // Picture button
+  if (picBtn) {
+    picBtn.addEventListener('click', () => { void takePicture(); });
+  }
+
   // Cancel button: stop current recording and reset UI
   if (cancelBtn) {
     cancelBtn.addEventListener('click', async () => {
@@ -882,10 +970,10 @@
   // Zoom controls
   // ========================================================================
 
-  const ZOOM_STEPS = Array.from({ length: 5 }, (_, i) => Math.pow(2, i / 4));
+  const ZOOM_STEPS = [1, 1.4, 2, 2.8, 4];
 
   function labelForZoom(scale) {
-    const fixed = (scale === 1 || Math.abs(scale - 2) < 1e-9) ? scale.toFixed(0) : scale.toFixed(1);
+    const fixed = Number.isInteger(scale) ? String(scale) : scale.toFixed(1);
     return `${fixed}x`;
   }
 

--- a/apps/videodelay/app.js
+++ b/apps/videodelay/app.js
@@ -281,7 +281,7 @@
 
   async function takePicture() {
     if (!picBtn) return;
-    const previous = picBtn.textContent || 'PIC';
+    const previous = picBtn.textContent || '📸';
     try {
       picBtn.disabled = true;
       picBtn.textContent = '...';

--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -67,7 +67,7 @@
     }
     #zoomControls {
       position: absolute;
-      bottom: 10px;
+      bottom: 78px;
       left: 10px;
       z-index: 5;
       display: flex;
@@ -102,7 +102,7 @@
       cursor: pointer;
     }
     #recBtn {
-      position: absolute; bottom: 10px; left: 10px; z-index: 5;
+      position: absolute; bottom: 10px; left: 110px; z-index: 5;
       background: rgba(255, 0, 0, 0.25); color: white;
       border: 2px solid red; font-size: 1.2em;
       padding: 0.8em 1.2em; border-radius: 14px;
@@ -119,11 +119,19 @@
       100% { transform: scale(1); }
     }
     #cancelBtn {
-      position: absolute; bottom: 10px; left: 120px; z-index: 5;
+      position: absolute; bottom: 10px; left: 230px; z-index: 5;
       background: rgba(255,255,255,0.1); color: white;
       border: 2px solid #888; font-size: 1.1em;
       padding: 0.7em 1.1em; border-radius: 14px;
       cursor: pointer; display: none;
+    }
+    #picBtn {
+      position: absolute; bottom: 10px; left: 10px; z-index: 6;
+      background: rgba(255,255,255,0.1); color: white;
+      border: 2px solid white; font-size: 1.2em;
+      padding: 0.8em 1.2em; border-radius: 14px;
+      cursor: pointer;
+      user-select: none;
     }
     @media (orientation: portrait) {
       #recBtn {
@@ -167,12 +175,13 @@
 
   <div id="delayLabel">Delay 10s</div>
   <button id="switchBtn" aria-label="Switch camera" title="Switch camera">📸↻</button>
+  <button id="picBtn" aria-label="Take picture" title="Take picture">PIC</button>
   <div id="zoomControls" role="group" aria-label="Zoom controls"></div>
   <button id="copyLinkBtn">copy app link 🔗</button>
   <button id="recBtn">REC</button>
   <button id="cancelBtn">CANCEL</button>
   <div id="recordDot"></div>
-  <div id="versionLabel">1.3.0</div>
+  <div id="versionLabel">1.4.0</div>
 
   <script src="logic.js"></script>
   <script src="app.js"></script>

--- a/apps/videodelay/index.html
+++ b/apps/videodelay/index.html
@@ -174,8 +174,8 @@
   <div id="frozenView"><span id="countdownText"></span></div>
 
   <div id="delayLabel">Delay 10s</div>
-  <button id="switchBtn" aria-label="Switch camera" title="Switch camera">📸↻</button>
-  <button id="picBtn" aria-label="Take picture" title="Take picture">PIC</button>
+  <button id="switchBtn" aria-label="Switch camera" title="Switch camera">↻</button>
+  <button id="picBtn" aria-label="Take picture" title="Take picture">📸</button>
   <div id="zoomControls" role="group" aria-label="Zoom controls"></div>
   <button id="copyLinkBtn">copy app link 🔗</button>
   <button id="recBtn">REC</button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a persistent picture button in the bottom-left corner so snapshots can be taken from either current main view (live or delayed/frozen)
- capture the currently visible main frame and immediately trigger native share (when supported) or direct download fallback
- replace zoom presets with `1x`, `1.4x`, `2x`, `2.8x`, and `4x`
- adjust control placement to avoid overlap with the picture button
- move the camera icon from the flip control to the picture button label (flip now shows rotate arrows only)

## Validation
- manual UI walkthrough confirms picture button in live and delayed main views, with save dialogs opening in both cases
- manual UI walkthrough confirms zoom options display exactly `1x`, `1.4x`, `2x`, `2.8x`, `4x` in live view
- manual UI walkthrough confirms flip button has no camera icon and picture button now uses camera icon, while picture capture still works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d507085e-556f-467f-9145-80ba7a8612b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d507085e-556f-467f-9145-80ba7a8612b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

